### PR TITLE
Room inrichten - room operable for implementation

### DIFF
--- a/app/src/main/java/com/digitalarchitects/rmc_app/MainActivity.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/MainActivity.kt
@@ -15,11 +15,11 @@ import com.digitalarchitects.rmc_app.ui.theme.RmcAppTheme
 
 class MainActivity : ComponentActivity() {
 
-    private val db by lazy{
+    private val db by lazy {
         Room.databaseBuilder(
             applicationContext,
             RmcRoomDatabase::class.java,
-            "RmcRoomDatabase.db"
+            "RmcRoomTest1.db"
         ).build()
     }
 

--- a/app/src/main/java/com/digitalarchitects/rmc_app/app/RmcApp.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/app/RmcApp.kt
@@ -2,17 +2,12 @@ package com.digitalarchitects.rmc_app.app
 
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.lifecycle.ViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.digitalarchitects.rmc_app.R
-import com.digitalarchitects.rmc_app.components.LargeHeadingTextComponent
 import com.digitalarchitects.rmc_app.data.myaccount.MyAccountViewModel
 import com.digitalarchitects.rmc_app.dummyDTO.DummyRentalDTO
 import com.digitalarchitects.rmc_app.dummyDTO.DummyUserDTO
@@ -44,7 +39,7 @@ enum class RmcScreen(@StringRes val title: Int) {
 }
 
 
-//@Preview(showBackground = true)
+@Preview(showBackground = true)
 @Composable
 fun RmcApp(
     viewModel: MyAccountViewModel = androidx.lifecycle.viewmodel.compose.viewModel(),
@@ -59,6 +54,7 @@ fun RmcApp(
                 onRegisterButtonClicked = { navController.navigate(RmcScreen.Register.name) },
                 onLoginButtonClicked = { navController.navigate(RmcScreen.Login.name) }
             )
+
         }
         composable(route = RmcScreen.Register.name) {
             RegisterScreen(
@@ -113,7 +109,8 @@ fun RmcApp(
         composable(route = RmcScreen.MyAccount.name) {
             MyAccountScreen(
                 viewModel = viewModel
-            )        }
+            )
+        }
         composable(route = RmcScreen.EditAccount.name) {
             TODO("Implement EditAccount screen")
             // EditAccountScreen()

--- a/app/src/main/java/com/digitalarchitects/rmc_app/room/RentalDao.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/room/RentalDao.kt
@@ -1,6 +1,7 @@
 package com.digitalarchitects.rmc_app.room
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Upsert
@@ -9,22 +10,22 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface RentalDao {
 
-//    @Query("SELECT * FROM rentaltable ORDER BY id ASC")
-//    fun getRentalOrderedById(): Flow<List<RentalTable>>
-//
-//    // TODO GET CURRENT Vehicle
-////    @Query("SELECT * FROM rentaltable LIMIT 1")
-////    fun getRental(): RentalTable
-//
-//    @Query("SELECT date FROM rentaltable LIMIT 1")
-//    fun getRentalDate(): String?
-//
-//    @Upsert
-//    suspend fun upsertRental(rental: RentalTable)
-//
-//    @Insert
-//    suspend fun insertRental(rental: RentalTable)
+    @Query("SELECT * FROM rentaltable ORDER BY id ASC")
+    fun getRentalOrderedById(): Flow<List<RentalTable>>
 
-//    @Delete
-//    suspend fun deleteRental()
+    // TODO GET CURRENT Vehicle
+//    @Query("SELECT * FROM rentaltable LIMIT 1")
+//    fun getRental(): RentalTable
+
+    @Query("SELECT date FROM rentaltable LIMIT 1")
+    fun getRentalDate(): String?
+
+    @Upsert
+    suspend fun upsertRental(rental: RentalTable)
+
+    @Insert
+    suspend fun insertRental(rental: RentalTable)
+
+    @Delete
+    suspend fun deleteRental(rental: RentalTable)
 }

--- a/app/src/main/java/com/digitalarchitects/rmc_app/room/RentalTable.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/room/RentalTable.kt
@@ -1,7 +1,6 @@
 package com.digitalarchitects.rmc_app.room
 
 import androidx.room.Entity
-//import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
 import androidx.room.TypeConverters
 import com.digitalarchitects.rmc_app.model.RentalStatus
@@ -10,6 +9,8 @@ import java.time.LocalDate
 @Entity
 @TypeConverters(LocalDateConverter::class)
 class RentalTable(
+    val vehicleId: Int,
+    val userId: Int,
     @TypeConverters(LocalDateConverter::class)
     val date: LocalDate,
     val price: Double,
@@ -19,14 +20,5 @@ class RentalTable(
     val distanceTravelled: Double,
     val score: Int,
     @PrimaryKey(autoGenerate = true)
-    val id: Int,
-//    @ForeignKey(
-//        entity = VehicleTable::class,
-//        parentColumns = ["id"],
-//        childColumns = ["vehicleId"],
-//        onDelete = ForeignKey.CASCADE
-//    )
-    val vehicleId: Int,
-//    @ForeignKey()
-    val userId: Int,
+    val id: Int
 )

--- a/app/src/main/java/com/digitalarchitects/rmc_app/room/RentalTable.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/room/RentalTable.kt
@@ -1,6 +1,7 @@
 package com.digitalarchitects.rmc_app.room
 
 import androidx.room.Entity
+//import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
 import androidx.room.TypeConverters
 import com.digitalarchitects.rmc_app.model.RentalStatus
@@ -8,9 +9,7 @@ import java.time.LocalDate
 
 @Entity
 @TypeConverters(LocalDateConverter::class)
-class RentalTable (
-    val vehicleId: Int,
-    val userId: Int,
+class RentalTable(
     @TypeConverters(LocalDateConverter::class)
     val date: LocalDate,
     val price: Double,
@@ -20,5 +19,14 @@ class RentalTable (
     val distanceTravelled: Double,
     val score: Int,
     @PrimaryKey(autoGenerate = true)
-    val id: Int
+    val id: Int,
+//    @ForeignKey(
+//        entity = VehicleTable::class,
+//        parentColumns = ["id"],
+//        childColumns = ["vehicleId"],
+//        onDelete = ForeignKey.CASCADE
+//    )
+    val vehicleId: Int,
+//    @ForeignKey()
+    val userId: Int,
 )

--- a/app/src/main/java/com/digitalarchitects/rmc_app/room/RmcRoomDatabase.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/room/RmcRoomDatabase.kt
@@ -3,15 +3,14 @@ package com.digitalarchitects.rmc_app.room
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverter
-import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 @Database(
-    entities = [UserTable::class, /*VehicleTable::class, RentalTable::class*/],
-    version= 1
+    version = 1,
+    entities = [UserTable::class, VehicleTable::class, RentalTable::class]
 )
-abstract class RmcRoomDatabase:RoomDatabase() {
+abstract class RmcRoomDatabase : RoomDatabase() {
     abstract val userDao: UserDao
     abstract val vehicleDao: VehicleDao
     abstract val rentalDao: RentalDao
@@ -31,15 +30,3 @@ class LocalDateConverter {
         return value?.let { LocalDate.parse(it, formatter) }
     }
 }
-
-//
-//class BigDecimalConverter {
-//    @TypeConverter
-//    fun fromBigDecimal(value: BigDecimal?): String? {
-//        return value?.toString()
-//    }
-//    @TypeConverter
-//    fun toBigDecimal(value: String?): BigDecimal? {
-//        return value?.let { BigDecimal(it) }
-//    }
-//}

--- a/app/src/main/java/com/digitalarchitects/rmc_app/room/UserDao.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/room/UserDao.kt
@@ -25,6 +25,6 @@ interface UserDao {
     @Insert
     suspend fun insertUser(user:UserTable)
 
-//    @Delete
-//    suspend fun deleteUser()
+    @Delete
+    suspend fun deleteUser(user:UserTable)
 }

--- a/app/src/main/java/com/digitalarchitects/rmc_app/room/VehicleDao.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/room/VehicleDao.kt
@@ -1,29 +1,31 @@
 package com.digitalarchitects.rmc_app.room
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface VehicleDao {
 
-//    @Query("SELECT * FROM vehicletable ORDER BY id ASC")
-//    fun getVehiclesOrderedById(): Flow<List<VehicleTable>>
+    @Query("SELECT * FROM vehicletable ORDER BY id ASC")
+    fun getVehiclesOrderedById(): Flow<List<VehicleTable>>
 
-    // TODO GET CURRENT Vehicle
+//     TODO GET CURRENT Vehicle
 //    @Query("SELECT * FROM vehicletable LIMIT 1")
 //    fun getVehicle(): VehicleTable
-//
-//    @Query("SELECT model FROM vehicletable LIMIT 1")
-//    fun getVehicleModel(): String?
-//
-//    @Upsert
-//    suspend fun upsertVehicle(vehicle: VehicleTable)
-//
-//    @Insert
-//    suspend fun insertUser(vehicle: VehicleTable)
 
-//    @Delete
-//    suspend fun deleteVehicle()
+    @Query("SELECT model FROM vehicletable LIMIT 1")
+    fun getVehicleModel(): String?
+
+    @Upsert
+    suspend fun upsertVehicle(vehicle: VehicleTable)
+
+    @Insert
+    suspend fun insertUser(vehicle: VehicleTable)
+
+    @Delete
+    suspend fun deleteVehicle(vehicle: VehicleTable)
 }

--- a/app/src/main/java/com/digitalarchitects/rmc_app/room/VehicleTable.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/room/VehicleTable.kt
@@ -3,11 +3,10 @@ package com.digitalarchitects.rmc_app.room
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import androidx.room.TypeConverters
 import com.digitalarchitects.rmc_app.model.EngineType
 
 @Entity
-class VehicleTable (
+class VehicleTable(
     val userId: Int,
     val brand: String,
     val model: String,


### PR DESCRIPTION
Introductory:
Room is een library voor een SQLite database, dit is een module in de app welke draait naast de composable UI's.(dus client side)
Door "lazy" wordt de room db alleen geinstantieerd wanneer er iets van data wordt aangesproken.
Retrofit zorgt voor het ophalen en wegschrijven van data via de api, room zorgt voor de lokale persistentie van data.  Deze synschroniseren met elkander wanneer nodig. Hierdoor draait de ap sneller, minder data gebruik en ontlasting op de server.

Overwegingen:
Door de simpliciteit van onze datalaag en entiteiten zijn data relaties in room niet direct nodig. Vanuit een single truth en keep it simple stupid is door geen constraints te definieren in room de api en haar data altijd leidend. 

Richtlijn:
Alle data interacties van de UI gaan via de viewmodel naar room. Room synschroniseerd met retrofit welke requests doet met de api.

Gebruik
Via de "app inspection" in Androidstudio( view > tool window > app inspection, dan verschijnt deze linkertoolbar als een hoed met bril) zit de database inspector waarin je de db kan inzien en direct queries ingang kan zetten. Gebruik livedata om real time de data in database te monitoren.
Wanneer je in migratie of conversie hell terechtkomt verander dan de naam van de db in de mainactivity van "RmcRoomTest1.db" naar "RmcRoomTest2.db" bv. Dan start je met een frisse instantie, zie ook wat er gebeurd via de database inspector.
Er is een apart Room module aangemaakt in de root. Hier zijn de files met de DB class met haar table classes te vinden. Queries gebeuren via de DAO, hier kan voor de functionaliteit van de ap aan ontwikkeldtoegevoegd worden.
Via de screen viewmodel spreek je de benodigde data entiteit dao's aan. 
Als voorbeeld voor het toevoegen van dummydata aan de db en het ophalen van deze dummdata zie de myaccount screen composable.


