### PR TITLE
Edit Account screen composable with room implementation

### DIFF
--- a/app/src/main/java/com/digitalarchitects/rmc_app/MainActivity.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/MainActivity.kt
@@ -15,11 +15,11 @@ import com.digitalarchitects.rmc_app.ui.theme.RmcAppTheme
 
 class MainActivity : ComponentActivity() {
 
-    private val db by lazy{
+    private val db by lazy {
         Room.databaseBuilder(
             applicationContext,
             RmcRoomDatabase::class.java,
-            "RmcRoomDatabase.db"
+            "RmcRoomTest1.db"
         ).build()
     }
 

--- a/app/src/main/java/com/digitalarchitects/rmc_app/MainActivity.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.room.Room
 import com.digitalarchitects.rmc_app.app.RmcApp
+import com.digitalarchitects.rmc_app.data.editmyaccount.EditMyAccountViewModel
 import com.digitalarchitects.rmc_app.data.myaccount.MyAccountViewModel
 import com.digitalarchitects.rmc_app.room.RmcRoomDatabase
 import com.digitalarchitects.rmc_app.ui.theme.RmcAppTheme
@@ -31,6 +32,14 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    private val viewModel2: EditMyAccountViewModel by viewModels {
+        object : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                return EditMyAccountViewModel(db.userDao) as T
+            }
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         installSplashScreen().setKeepOnScreenCondition {
@@ -39,7 +48,7 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             RmcAppTheme {
-                RmcApp(viewModel = viewModel)
+                RmcApp(viewModel = viewModel, viewModel2 = viewModel2)
             }
         }
     }

--- a/app/src/main/java/com/digitalarchitects/rmc_app/app/RmcApp.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/app/RmcApp.kt
@@ -111,7 +111,8 @@ fun RmcApp(
         }
         composable(route = RmcScreen.MyAccount.name) {
             MyAccountScreen(
-                viewModel = viewModel
+                viewModel = viewModel,
+                onEditMyAccountButtonClicked = { navController.navigate(RmcScreen.EditMyAccount.name) }
             )
         }
         composable(route = RmcScreen.EditMyAccount.name) {

--- a/app/src/main/java/com/digitalarchitects/rmc_app/app/RmcApp.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/app/RmcApp.kt
@@ -50,7 +50,7 @@ fun RmcApp(
 ) {
     NavHost(
         navController = navController,
-        startDestination = RmcScreen.MyAccount.name,
+        startDestination = RmcScreen.Welcome.name,
     ) {
         composable(route = RmcScreen.Welcome.name) {
             WelcomeScreen(

--- a/app/src/main/java/com/digitalarchitects/rmc_app/app/RmcApp.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/app/RmcApp.kt
@@ -8,10 +8,12 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.digitalarchitects.rmc_app.R
+import com.digitalarchitects.rmc_app.data.editmyaccount.EditMyAccountViewModel
 import com.digitalarchitects.rmc_app.data.myaccount.MyAccountViewModel
 import com.digitalarchitects.rmc_app.dummyDTO.DummyRentalDTO
 import com.digitalarchitects.rmc_app.dummyDTO.DummyUserDTO
 import com.digitalarchitects.rmc_app.dummyDTO.DummyVehicleDTO
+import com.digitalarchitects.rmc_app.screens.EditMyAccountScreen
 import com.digitalarchitects.rmc_app.screens.LoginScreen
 import com.digitalarchitects.rmc_app.screens.MyAccountScreen
 import com.digitalarchitects.rmc_app.screens.MyVehiclesScreen
@@ -35,7 +37,7 @@ enum class RmcScreen(@StringRes val title: Int) {
     MyVehicles(title = R.string.screen_title_my_vehicles),
     RegisterVehicle(title = R.string.screen_title_register_vehicle),
     MyAccount(title = R.string.screen_title_my_account),
-    EditAccount(title = R.string.screen_title_edit_account)
+    EditMyAccount(title = R.string.screen_title_edit_account)
 }
 
 
@@ -43,11 +45,12 @@ enum class RmcScreen(@StringRes val title: Int) {
 @Composable
 fun RmcApp(
     viewModel: MyAccountViewModel = androidx.lifecycle.viewmodel.compose.viewModel(),
+    viewModel2: EditMyAccountViewModel = androidx.lifecycle.viewmodel.compose.viewModel(),
     navController: NavHostController = rememberNavController()
 ) {
     NavHost(
         navController = navController,
-        startDestination = RmcScreen.Welcome.name,
+        startDestination = RmcScreen.EditMyAccount.name,
     ) {
         composable(route = RmcScreen.Welcome.name) {
             WelcomeScreen(
@@ -111,9 +114,11 @@ fun RmcApp(
                 viewModel = viewModel
             )
         }
-        composable(route = RmcScreen.EditAccount.name) {
-            TODO("Implement EditAccount screen")
-            // EditAccountScreen()
+        composable(route = RmcScreen.EditMyAccount.name) {
+            EditMyAccountScreen(
+                onNavigateUp = { navController.navigate(RmcScreen.MyAccount.name) },
+                viewModel = viewModel2
+            )
 
         }
     }

--- a/app/src/main/java/com/digitalarchitects/rmc_app/app/RmcApp.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/app/RmcApp.kt
@@ -50,7 +50,7 @@ fun RmcApp(
 ) {
     NavHost(
         navController = navController,
-        startDestination = RmcScreen.EditMyAccount.name,
+        startDestination = RmcScreen.MyAccount.name,
     ) {
         composable(route = RmcScreen.Welcome.name) {
             WelcomeScreen(

--- a/app/src/main/java/com/digitalarchitects/rmc_app/app/RmcApp.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/app/RmcApp.kt
@@ -2,17 +2,12 @@ package com.digitalarchitects.rmc_app.app
 
 import androidx.annotation.StringRes
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.lifecycle.ViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.digitalarchitects.rmc_app.R
-import com.digitalarchitects.rmc_app.components.LargeHeadingTextComponent
 import com.digitalarchitects.rmc_app.data.myaccount.MyAccountViewModel
 import com.digitalarchitects.rmc_app.dummyDTO.DummyRentalDTO
 import com.digitalarchitects.rmc_app.dummyDTO.DummyUserDTO
@@ -44,7 +39,7 @@ enum class RmcScreen(@StringRes val title: Int) {
 }
 
 
-//@Preview(showBackground = true)
+@Preview(showBackground = true)
 @Composable
 fun RmcApp(
     viewModel: MyAccountViewModel = androidx.lifecycle.viewmodel.compose.viewModel(),
@@ -59,6 +54,7 @@ fun RmcApp(
                 onRegisterButtonClicked = { navController.navigate(RmcScreen.Register.name) },
                 onLoginButtonClicked = { navController.navigate(RmcScreen.Login.name) }
             )
+
         }
         composable(route = RmcScreen.Register.name) {
             RegisterScreen(
@@ -113,7 +109,8 @@ fun RmcApp(
         composable(route = RmcScreen.MyAccount.name) {
             MyAccountScreen(
                 viewModel = viewModel
-            )        }
+            )
+        }
         composable(route = RmcScreen.EditAccount.name) {
             TODO("Implement EditAccount screen")
             // EditAccountScreen()

--- a/app/src/main/java/com/digitalarchitects/rmc_app/components/CommonUI.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/components/CommonUI.kt
@@ -159,7 +159,7 @@ fun RmcUserIcon(
             .padding(dimensionResource(R.dimen.padding_small))
             .clip(CircleShape)
             .border(1.dp, colorResource(R.color.purple_200), CircleShape)
-            .clickable { onClick },
+            .clickable { onClick() },
         contentScale = ContentScale.Crop,
         painter = painterResource(userIcon),
         contentDescription = null

--- a/app/src/main/java/com/digitalarchitects/rmc_app/data/editmyaccount/EditMyAccountUIEvent.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/data/editmyaccount/EditMyAccountUIEvent.kt
@@ -1,10 +1,10 @@
 package com.digitalarchitects.rmc_app.data.editmyaccount
 
-import com.digitalarchitects.rmc_app.data.myaccount.MyAccountUIEvent
 import com.digitalarchitects.rmc_app.model.UserType
 
 sealed interface EditMyAccountUIEvent {
 
+    object InsertUser: EditMyAccountUIEvent
     object UpsertUser: EditMyAccountUIEvent
     object ShowUser: EditMyAccountUIEvent
     data class SetEmail(val email: String) : EditMyAccountUIEvent

--- a/app/src/main/java/com/digitalarchitects/rmc_app/data/editmyaccount/EditMyAccountUIEvent.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/data/editmyaccount/EditMyAccountUIEvent.kt
@@ -8,6 +8,7 @@ sealed interface EditMyAccountUIEvent {
     data class SetFirstName(val firstName: String): EditMyAccountUIEvent
     data class SetLastName(val lastName: String) : EditMyAccountUIEvent
     data class SetPhone(val phone: String) : EditMyAccountUIEvent
+    data class SetPassword(val password: String) : EditMyAccountUIEvent
     data class SetStreet(val street: String) : EditMyAccountUIEvent
     data class SetBuildingNumber(val buildingNumber: String) : EditMyAccountUIEvent
     data class SetZipCode(val zipCode: String) : EditMyAccountUIEvent

--- a/app/src/main/java/com/digitalarchitects/rmc_app/data/editmyaccount/EditMyAccountUIEvent.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/data/editmyaccount/EditMyAccountUIEvent.kt
@@ -1,8 +1,12 @@
 package com.digitalarchitects.rmc_app.data.editmyaccount
 
+import com.digitalarchitects.rmc_app.data.myaccount.MyAccountUIEvent
 import com.digitalarchitects.rmc_app.model.UserType
 
 sealed interface EditMyAccountUIEvent {
+
+    object UpsertUser: EditMyAccountUIEvent
+    object ShowUser: EditMyAccountUIEvent
     data class SetEmail(val email: String) : EditMyAccountUIEvent
     data class SetUserType(val userType: UserType) : EditMyAccountUIEvent
     data class SetFirstName(val firstName: String): EditMyAccountUIEvent

--- a/app/src/main/java/com/digitalarchitects/rmc_app/data/editmyaccount/EditMyAccountUIState.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/data/editmyaccount/EditMyAccountUIState.kt
@@ -12,6 +12,7 @@ data class EditMyAccountUIState (
     val buildingNumber: String = "",
     val zipCode: String = "",
     val city: String = "",
+    val password: String = "" ,
     val imageResourceId: Int = 0,
     val id: Int = 0,
 )

--- a/app/src/main/java/com/digitalarchitects/rmc_app/data/editmyaccount/EditMyAccountViewModel.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/data/editmyaccount/EditMyAccountViewModel.kt
@@ -6,9 +6,12 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.digitalarchitects.rmc_app.app.RmcScreen
+import com.digitalarchitects.rmc_app.data.myaccount.MyAccountUIEvent
 import com.digitalarchitects.rmc_app.data.myaccount.MyAccountUIState
+import com.digitalarchitects.rmc_app.model.UserType
 import com.digitalarchitects.rmc_app.room.UserDao
 import com.digitalarchitects.rmc_app.room.UserTable
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -16,72 +19,188 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 
 
 class EditMyAccountViewModel(
     private val dao: UserDao,
-    ): ViewModel() {
+) : ViewModel() {
 
     private val _state = MutableStateFlow(EditMyAccountUIState())
     private val _uiState = _state
     val uiState: StateFlow<EditMyAccountUIState> = _uiState.asStateFlow()
 
-//    private val _state = MutableStateFlow(EditMyAccountUIState())
+    //    private val _state = MutableStateFlow(EditMyAccountUIState())
 //    val state = _state.stateIn(
 //        viewModelScope,
 //        SharingStarted.WhileSubscribed(5000),
 //        EditMyAccountUIState()
 //    )
-    fun onEvent(event: EditMyAccountUIEvent){
-        when(event){
+    fun onEvent(event: EditMyAccountUIEvent) {
+        when (event) {
+            is EditMyAccountUIEvent.ShowUser -> {
+                try {
+                    runBlocking {
+                        val getUser = withContext(Dispatchers.IO) {
+                            dao.getUserById()
+                        }
+                        val email = getUser.email
+                        val firstName = getUser.firstName
+                        val lastName = getUser.lastName
+                        val phone = getUser.phone
+                        val street = getUser.street
+                        val buildingNumber = getUser.buildingNumber
+                        val zipCode = getUser.zipCode
+                        val city = getUser.city
+
+                        _state.value = _state.value.copy(
+                            email = "$email",
+                            firstName = "$firstName",
+                            lastName = "$lastName",
+                            phone = "$phone",
+                            street = "$street",
+                            buildingNumber = "$buildingNumber",
+                            zipCode = "$zipCode",
+                            city = "$city"
+                        )
+                    }
+                } catch (e: Exception) {
+                    _state.value = _state.value.copy(firstName = "Error")
+                }
+            }
+
+            is EditMyAccountUIEvent.UpsertUser -> {
+//                try{
+                val user = UserTable(
+                    email = "john.doe@example.com",
+                    userType = UserType.CLIENT,
+                    firstName = "John",
+                    lastName = "Doe",
+                    phone = "+1234567890",
+                    street = "Main St",
+                    buildingNumber = "123",
+                    zipCode = "12345",
+                    city = "Cityville",
+                    id = 1,
+                    imageResourceId = 123
+                )
+                runBlocking {
+                    val email = withContext(Dispatchers.IO) {
+                        dao.upsertUser(user)
+                    }
+                    val firstName = withContext(Dispatchers.IO) {
+                        dao.upsertUser(user)
+                    }
+                    val lastName = withContext(Dispatchers.IO) {
+                        dao.upsertUser(user)
+                    }
+                    val phone = withContext(Dispatchers.IO) {
+                        dao.upsertUser(user)
+                    }
+                    val street = withContext(Dispatchers.IO) {
+                        dao.upsertUser(user)
+                    }
+                    val buildingNumber = withContext(Dispatchers.IO) {
+                        dao.upsertUser(user)
+                    }
+                    val zipCode = withContext(Dispatchers.IO) {
+                        dao.upsertUser(user)
+                    }
+                    val city = withContext(Dispatchers.IO) {
+                        dao.upsertUser(user)
+                    }
+                    _state.value = _state.value.copy(
+                        email = "$email",
+                        firstName = "$firstName",
+                        lastName = "$lastName",
+                        phone = "$phone",
+                        street = "$street",
+                        buildingNumber = "$buildingNumber",
+                        zipCode = "$zipCode",
+                        city = "$city"
+                    )
+                }
+//                } catch(e: Exception){
+//                    _state.value = _state.value.copy(firstName = "Error")
+//                }
+            }
+
             is EditMyAccountUIEvent.SetBuildingNumber -> {
-                _state.update { it.copy(
-                    buildingNumber = event.buildingNumber
-                )}
+                _state.update {
+                    it.copy(
+                        buildingNumber = event.buildingNumber
+                    )
+                }
             }
+
             is EditMyAccountUIEvent.SetCity -> {
-                _state.update { it.copy(
-                    city = event.city
-                )}
+                _state.update {
+                    it.copy(
+                        city = event.city
+                    )
+                }
             }
+
             is EditMyAccountUIEvent.SetEmail -> {
-                _state.update { it.copy(
-                    email = event.email
-                )}
+                _state.update {
+                    it.copy(
+                        email = event.email
+                    )
+                }
             }
+
             is EditMyAccountUIEvent.SetFirstName -> {
-                _state.update { it.copy(
-                    firstName = event.firstName
-                )}
+                _state.update {
+                    it.copy(
+                        firstName = event.firstName
+                    )
+                }
             }
+
             is EditMyAccountUIEvent.SetId -> TODO()
             is EditMyAccountUIEvent.SetImageResourceId -> TODO()
             is EditMyAccountUIEvent.SetPassword -> {
-                _state.update { it.copy(
-                    lastName = event.password
-                )}
+                _state.update {
+                    it.copy(
+                        lastName = event.password
+                    )
+                }
             }
+
             is EditMyAccountUIEvent.SetLastName -> {
-                _state.update { it.copy(
-                    lastName = event.lastName
-                )}
+                _state.update {
+                    it.copy(
+                        lastName = event.lastName
+                    )
+                }
             }
+
             is EditMyAccountUIEvent.SetPhone -> {
-                _state.update { it.copy(
-                    phone = event.phone
-                )}
+                _state.update {
+                    it.copy(
+                        phone = event.phone
+                    )
+                }
             }
+
             is EditMyAccountUIEvent.SetStreet -> {
-                _state.update { it.copy(
-                    street = event.street
-                )}
+                _state.update {
+                    it.copy(
+                        street = event.street
+                    )
+                }
             }
+
             is EditMyAccountUIEvent.SetUserType -> TODO()
             is EditMyAccountUIEvent.SetZipCode -> {
-                _state.update { it.copy(
-                    zipCode = event.zipCode
-                )}
+                _state.update {
+                    it.copy(
+                        zipCode = event.zipCode
+                    )
+                }
             }
+
             is EditMyAccountUIEvent.User -> TODO()
             EditMyAccountUIEvent.ConfirmEditMyAccountButtonClicked -> {
                 val email = uiState.value.email
@@ -96,7 +215,7 @@ class EditMyAccountViewModel(
 //                val imageResourceId = state.value.imageResourceId
 //                val id = state.value.id
                 // TODO ADD MORE PROPERTIES TO IF
-                if(firstName.isBlank() || lastName.isBlank() || phone.isBlank()){
+                if (firstName.isBlank() || lastName.isBlank() || phone.isBlank()) {
                     return
                 }
                 val user = UserTable(
@@ -116,9 +235,11 @@ class EditMyAccountViewModel(
 
 
             }
+
             EditMyAccountUIEvent.CancelEditMyAccountButtonClicked -> {
 //                navController.navigate(RmcScreen.MyAccount.name)
             }
+
             EditMyAccountUIEvent.DeleteMyAccountButtonClicked -> {
                 viewModelScope.launch {
 //                    dao.deleteUser()

--- a/app/src/main/java/com/digitalarchitects/rmc_app/data/editmyaccount/EditMyAccountViewModel.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/data/editmyaccount/EditMyAccountViewModel.kt
@@ -6,10 +6,13 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.digitalarchitects.rmc_app.app.RmcScreen
+import com.digitalarchitects.rmc_app.data.myaccount.MyAccountUIState
 import com.digitalarchitects.rmc_app.room.UserDao
 import com.digitalarchitects.rmc_app.room.UserTable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -17,15 +20,18 @@ import kotlinx.coroutines.launch
 
 class EditMyAccountViewModel(
     private val dao: UserDao,
-    private val navController: NavController
     ): ViewModel() {
 
     private val _state = MutableStateFlow(EditMyAccountUIState())
-    val state = _state.stateIn(
-        viewModelScope,
-        SharingStarted.WhileSubscribed(5000),
-        EditMyAccountUIState()
-    )
+    private val _uiState = _state
+    val uiState: StateFlow<EditMyAccountUIState> = _uiState.asStateFlow()
+
+//    private val _state = MutableStateFlow(EditMyAccountUIState())
+//    val state = _state.stateIn(
+//        viewModelScope,
+//        SharingStarted.WhileSubscribed(5000),
+//        EditMyAccountUIState()
+//    )
     fun onEvent(event: EditMyAccountUIEvent){
         when(event){
             is EditMyAccountUIEvent.SetBuildingNumber -> {
@@ -50,6 +56,11 @@ class EditMyAccountViewModel(
             }
             is EditMyAccountUIEvent.SetId -> TODO()
             is EditMyAccountUIEvent.SetImageResourceId -> TODO()
+            is EditMyAccountUIEvent.SetPassword -> {
+                _state.update { it.copy(
+                    lastName = event.password
+                )}
+            }
             is EditMyAccountUIEvent.SetLastName -> {
                 _state.update { it.copy(
                     lastName = event.lastName
@@ -73,15 +84,15 @@ class EditMyAccountViewModel(
             }
             is EditMyAccountUIEvent.User -> TODO()
             EditMyAccountUIEvent.ConfirmEditMyAccountButtonClicked -> {
-                val email = state.value.email
+                val email = uiState.value.email
 //                val userType = state.value.userType
-                val firstName = state.value.firstName
-                val lastName = state.value.lastName
-                val phone = state.value.phone
-                val street = state.value.street
-                val buildingNumber = state.value.buildingNumber
-                val zipCode = state.value.zipCode
-                val city = state.value.city
+                val firstName = uiState.value.firstName
+                val lastName = uiState.value.lastName
+                val phone = uiState.value.phone
+                val street = uiState.value.street
+                val buildingNumber = uiState.value.buildingNumber
+                val zipCode = uiState.value.zipCode
+                val city = uiState.value.city
 //                val imageResourceId = state.value.imageResourceId
 //                val id = state.value.id
                 // TODO ADD MORE PROPERTIES TO IF
@@ -100,19 +111,19 @@ class EditMyAccountViewModel(
                 )
                 viewModelScope.launch {
                     dao.upsertUser(user = user)
-                    navController.navigate(RmcScreen.MyAccount.name)
+//                    navController.navigate(RmcScreen.MyAccount.name)
                 }
 
 
             }
             EditMyAccountUIEvent.CancelEditMyAccountButtonClicked -> {
-                navController.navigate(RmcScreen.MyAccount.name)
+//                navController.navigate(RmcScreen.MyAccount.name)
             }
             EditMyAccountUIEvent.DeleteMyAccountButtonClicked -> {
                 viewModelScope.launch {
 //                    dao.deleteUser()
                 }
-                navController.navigate(RmcScreen.Welcome.name)
+//                navController.navigate(RmcScreen.Welcome.name)
             }
         }
     }

--- a/app/src/main/java/com/digitalarchitects/rmc_app/data/editmyaccount/EditMyAccountViewModel.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/data/editmyaccount/EditMyAccountViewModel.kt
@@ -1,22 +1,14 @@
 package com.digitalarchitects.rmc_app.data.editmyaccount
 
-import androidx.compose.runtime.Composable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
-import com.digitalarchitects.rmc_app.app.RmcScreen
-import com.digitalarchitects.rmc_app.data.myaccount.MyAccountUIEvent
-import com.digitalarchitects.rmc_app.data.myaccount.MyAccountUIState
 import com.digitalarchitects.rmc_app.model.UserType
 import com.digitalarchitects.rmc_app.room.UserDao
 import com.digitalarchitects.rmc_app.room.UserTable
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -29,14 +21,8 @@ class EditMyAccountViewModel(
 
     private val _state = MutableStateFlow(EditMyAccountUIState())
     private val _uiState = _state
-    val uiState: StateFlow<EditMyAccountUIState> = _uiState.asStateFlow()
+    val uiState: StateFlow<EditMyAccountUIState> get() = _uiState.asStateFlow()
 
-    //    private val _state = MutableStateFlow(EditMyAccountUIState())
-//    val state = _state.stateIn(
-//        viewModelScope,
-//        SharingStarted.WhileSubscribed(5000),
-//        EditMyAccountUIState()
-//    )
     fun onEvent(event: EditMyAccountUIEvent) {
         when (event) {
             is EditMyAccountUIEvent.ShowUser -> {
@@ -55,75 +41,59 @@ class EditMyAccountViewModel(
                         val city = getUser.city
 
                         _state.value = _state.value.copy(
-                            email = "$email",
-                            firstName = "$firstName",
-                            lastName = "$lastName",
-                            phone = "$phone",
-                            street = "$street",
-                            buildingNumber = "$buildingNumber",
-                            zipCode = "$zipCode",
-                            city = "$city"
+                            email = email,
+                            firstName = firstName,
+                            lastName = lastName,
+                            phone = phone,
+                            street = street,
+                            buildingNumber = buildingNumber,
+                            zipCode = zipCode,
+                            city = city
                         )
                     }
+
                 } catch (e: Exception) {
-                    _state.value = _state.value.copy(firstName = "Error")
+//                    _state.value = _state.value.copy(firstName = "Error")
                 }
             }
 
-            is EditMyAccountUIEvent.UpsertUser -> {
-//                try{
-                val user = UserTable(
-                    email = "john.doe@example.com",
-                    userType = UserType.CLIENT,
-                    firstName = "John",
-                    lastName = "Doe",
-                    phone = "+1234567890",
-                    street = "Main St",
-                    buildingNumber = "123",
-                    zipCode = "12345",
-                    city = "Cityville",
-                    id = 1,
-                    imageResourceId = 123
-                )
-                runBlocking {
-                    val email = withContext(Dispatchers.IO) {
-                        dao.upsertUser(user)
-                    }
-                    val firstName = withContext(Dispatchers.IO) {
-                        dao.upsertUser(user)
-                    }
-                    val lastName = withContext(Dispatchers.IO) {
-                        dao.upsertUser(user)
-                    }
-                    val phone = withContext(Dispatchers.IO) {
-                        dao.upsertUser(user)
-                    }
-                    val street = withContext(Dispatchers.IO) {
-                        dao.upsertUser(user)
-                    }
-                    val buildingNumber = withContext(Dispatchers.IO) {
-                        dao.upsertUser(user)
-                    }
-                    val zipCode = withContext(Dispatchers.IO) {
-                        dao.upsertUser(user)
-                    }
-                    val city = withContext(Dispatchers.IO) {
-                        dao.upsertUser(user)
-                    }
-                    _state.value = _state.value.copy(
-                        email = "$email",
-                        firstName = "$firstName",
-                        lastName = "$lastName",
-                        phone = "$phone",
-                        street = "$street",
-                        buildingNumber = "$buildingNumber",
-                        zipCode = "$zipCode",
-                        city = "$city"
+            is EditMyAccountUIEvent.InsertUser -> {
+                try {
+                    val user = UserTable(
+                        email = "john.doe@example.com",
+                        userType = UserType.CLIENT,
+                        firstName = "John",
+                        lastName = "Doe",
+                        phone = "+1234567890",
+                        street = "Main St",
+                        buildingNumber = "123",
+                        zipCode = "12345",
+                        city = "Cityville",
+                        id = 1,
+                        imageResourceId = 123
                     )
+
+                    runBlocking {
+                        withContext(Dispatchers.IO) {
+                            dao.insertUser(user)
+                        }
+
+                        _state.value = _state.value.copy(
+                            email = user.email,
+                            firstName = user.firstName,
+                            lastName = user.lastName,
+                            phone = user.phone,
+                            street = user.street,
+                            buildingNumber = user.buildingNumber,
+                            zipCode = user.zipCode,
+                            city = user.city
+                        )
+                    }
+                } catch (e: Exception) {
+                    // Handle the exception or log an error
+                    // TODO ERROR MESSAGE
+                    // _state.value = _state.value.copy(firstName = "Error")
                 }
-//                } catch(e: Exception){
-//                    _state.value = _state.value.copy(firstName = "Error")
-//                }
             }
 
             is EditMyAccountUIEvent.SetBuildingNumber -> {
@@ -202,23 +172,22 @@ class EditMyAccountViewModel(
             }
 
             is EditMyAccountUIEvent.User -> TODO()
+
             EditMyAccountUIEvent.ConfirmEditMyAccountButtonClicked -> {
-                val email = uiState.value.email
+                val email = _uiState.value.email
 //                val userType = state.value.userType
-                val firstName = uiState.value.firstName
-                val lastName = uiState.value.lastName
-                val phone = uiState.value.phone
-                val street = uiState.value.street
-                val buildingNumber = uiState.value.buildingNumber
-                val zipCode = uiState.value.zipCode
-                val city = uiState.value.city
+                val firstName = _uiState.value.firstName
+                val lastName = _uiState.value.lastName
+                val phone = _uiState.value.phone
+                val street = _uiState.value.street
+                val buildingNumber = _uiState.value.buildingNumber
+                val zipCode = _uiState.value.zipCode
+                val city = _uiState.value.city
 //                val imageResourceId = state.value.imageResourceId
 //                val id = state.value.id
                 // TODO ADD MORE PROPERTIES TO IF
-                if (firstName.isBlank() || lastName.isBlank() || phone.isBlank()) {
-                    return
-                }
-                val user = UserTable(
+
+                val updatedUser = UserTable(
                     email = email,
                     firstName = firstName,
                     lastName = lastName,
@@ -226,10 +195,11 @@ class EditMyAccountViewModel(
                     street = street,
                     buildingNumber = buildingNumber,
                     zipCode = zipCode,
-                    city = city
+                    city = city,
+                    id = 1
                 )
                 viewModelScope.launch {
-                    dao.upsertUser(user = user)
+                    dao.upsertUser(user = updatedUser)
 //                    navController.navigate(RmcScreen.MyAccount.name)
                 }
 
@@ -246,6 +216,8 @@ class EditMyAccountViewModel(
                 }
 //                navController.navigate(RmcScreen.Welcome.name)
             }
+
+            EditMyAccountUIEvent.UpsertUser -> TODO()
         }
     }
 }

--- a/app/src/main/java/com/digitalarchitects/rmc_app/data/myaccount/MyAccountUIEvent.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/data/myaccount/MyAccountUIEvent.kt
@@ -2,6 +2,7 @@ package com.digitalarchitects.rmc_app.data.myaccount
 
 
 sealed interface MyAccountUIEvent {
+    object InsertUser: MyAccountUIEvent
     object UpsertUser: MyAccountUIEvent
     object ShowUser: MyAccountUIEvent
     object onEditMyAccountButtonClicked: MyAccountUIEvent

--- a/app/src/main/java/com/digitalarchitects/rmc_app/data/myaccount/MyAccountViewModel.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/data/myaccount/MyAccountViewModel.kt
@@ -1,6 +1,6 @@
 package com.digitalarchitects.rmc_app.data.myaccount
+
 import androidx.lifecycle.ViewModel
-import com.digitalarchitects.rmc_app.data.editmyaccount.EditMyAccountUIEvent
 import com.digitalarchitects.rmc_app.model.UserType
 import com.digitalarchitects.rmc_app.room.UserDao
 import com.digitalarchitects.rmc_app.room.UserTable
@@ -14,65 +14,73 @@ import kotlinx.coroutines.withContext
 class MyAccountViewModel(
     private val dao: UserDao
 //    private val navController: NavController
-): ViewModel() {
+) : ViewModel() {
     private val _state = MutableStateFlow(MyAccountUIState())
     private val _uiState = _state
     val uiState: StateFlow<MyAccountUIState> = _uiState.asStateFlow()
-    fun onEvent(event: MyAccountUIEvent){
+    fun onEvent(event: MyAccountUIEvent) {
         when (event) {
             is MyAccountUIEvent.ShowUser -> {
-                try{
+                try {
                     runBlocking {
                         val firstName = withContext(Dispatchers.IO) {
                             dao.getFirstName()
                         }
-                       _state.value =  _state.value.copy(firstName = "$firstName")
+                        _state.value = _state.value.copy(firstName = "$firstName")
                     }
-                } catch(e: Exception){
+                } catch (e: Exception) {
                     _state.value = _state.value.copy(firstName = "Error")
                 }
             }
-            is MyAccountUIEvent.UpsertUser -> {
-//                try{
-                val user= UserTable(
-                    email = "john.doe@example.com",
-                    userType = UserType.CLIENT,
-                    firstName = "John",
-                    lastName = "Doe",
-                    phone = "+1234567890",
-                    street = "Main St",
-                    buildingNumber = "123",
-                    zipCode = "12345",
-                    city = "Cityville",
-                    id = 1,
-                    imageResourceId = 123
-                )
+
+            is MyAccountUIEvent.InsertUser -> {
+                try {
+                    val user = UserTable(
+                        email = "john.doe@example.com",
+                        userType = UserType.CLIENT,
+                        firstName = "John",
+                        lastName = "Doe",
+                        phone = "+1234567890",
+                        street = "Main St",
+                        buildingNumber = "123",
+                        zipCode = "12345",
+                        city = "Cityville",
+                        id = 1,
+                        imageResourceId = 123
+                    )
                     runBlocking {
                         val firstName = withContext(Dispatchers.IO) {
-                            dao.upsertUser(user)
+                            dao.insertUser(user)
                         }
-                        _state.value =  _state.value.copy(firstName = "$firstName")
+                        _state.value = _state.value.copy(firstName = "$firstName")
                     }
-//                } catch(e: Exception){
+                } catch (e: Exception) {
 //                    _state.value = _state.value.copy(firstName = "Error")
-//                }
+                }
             }
+
             MyAccountUIEvent.onEditMyAccountButtonClicked -> {
                 /*navController.navigate(RmcScreen.EditAccount.name)*/
             }
+
             MyAccountUIEvent.onLogoutButtonClicked -> {
                 // TODO: LOG OUT FUNCTION
 //                navController.navigate(RmcScreen.Login.name)
             }
+
             MyAccountUIEvent.onMyRentalsButtonClicked -> {
                 /*navController.navigate(RmcScreen.MyRentals.name)*/
             }
+
             MyAccountUIEvent.onMyVehiclesButtonClicked -> {
 //                navController.navigate(RmcScreen.MyVehicles.name)
             }
+
             MyAccountUIEvent.onRentOutMyCarButtonClicked -> {
 //                navController.navigate(RmcScreen.RentMyCar.name)
             }
+
+            MyAccountUIEvent.UpsertUser -> TODO()
         }
     }
 }

--- a/app/src/main/java/com/digitalarchitects/rmc_app/room/RentalDao.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/room/RentalDao.kt
@@ -1,6 +1,7 @@
 package com.digitalarchitects.rmc_app.room
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Upsert
@@ -9,22 +10,22 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface RentalDao {
 
-//    @Query("SELECT * FROM rentaltable ORDER BY id ASC")
-//    fun getRentalOrderedById(): Flow<List<RentalTable>>
-//
-//    // TODO GET CURRENT Vehicle
-////    @Query("SELECT * FROM rentaltable LIMIT 1")
-////    fun getRental(): RentalTable
-//
-//    @Query("SELECT date FROM rentaltable LIMIT 1")
-//    fun getRentalDate(): String?
-//
-//    @Upsert
-//    suspend fun upsertRental(rental: RentalTable)
-//
-//    @Insert
-//    suspend fun insertRental(rental: RentalTable)
+    @Query("SELECT * FROM rentaltable ORDER BY id ASC")
+    fun getRentalOrderedById(): Flow<List<RentalTable>>
 
-//    @Delete
-//    suspend fun deleteRental()
+    // TODO GET CURRENT Vehicle
+//    @Query("SELECT * FROM rentaltable LIMIT 1")
+//    fun getRental(): RentalTable
+
+    @Query("SELECT date FROM rentaltable LIMIT 1")
+    fun getRentalDate(): String?
+
+    @Upsert
+    suspend fun upsertRental(rental: RentalTable)
+
+    @Insert
+    suspend fun insertRental(rental: RentalTable)
+
+    @Delete
+    suspend fun deleteRental(rental: RentalTable)
 }

--- a/app/src/main/java/com/digitalarchitects/rmc_app/room/RentalTable.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/room/RentalTable.kt
@@ -1,7 +1,6 @@
 package com.digitalarchitects.rmc_app.room
 
 import androidx.room.Entity
-//import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
 import androidx.room.TypeConverters
 import com.digitalarchitects.rmc_app.model.RentalStatus
@@ -10,6 +9,8 @@ import java.time.LocalDate
 @Entity
 @TypeConverters(LocalDateConverter::class)
 class RentalTable(
+    val vehicleId: Int,
+    val userId: Int,
     @TypeConverters(LocalDateConverter::class)
     val date: LocalDate,
     val price: Double,
@@ -19,14 +20,5 @@ class RentalTable(
     val distanceTravelled: Double,
     val score: Int,
     @PrimaryKey(autoGenerate = true)
-    val id: Int,
-//    @ForeignKey(
-//        entity = VehicleTable::class,
-//        parentColumns = ["id"],
-//        childColumns = ["vehicleId"],
-//        onDelete = ForeignKey.CASCADE
-//    )
-    val vehicleId: Int,
-//    @ForeignKey()
-    val userId: Int,
+    val id: Int
 )

--- a/app/src/main/java/com/digitalarchitects/rmc_app/room/RentalTable.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/room/RentalTable.kt
@@ -1,6 +1,7 @@
 package com.digitalarchitects.rmc_app.room
 
 import androidx.room.Entity
+//import androidx.room.ForeignKey
 import androidx.room.PrimaryKey
 import androidx.room.TypeConverters
 import com.digitalarchitects.rmc_app.model.RentalStatus
@@ -8,9 +9,7 @@ import java.time.LocalDate
 
 @Entity
 @TypeConverters(LocalDateConverter::class)
-class RentalTable (
-    val vehicleId: Int,
-    val userId: Int,
+class RentalTable(
     @TypeConverters(LocalDateConverter::class)
     val date: LocalDate,
     val price: Double,
@@ -20,5 +19,14 @@ class RentalTable (
     val distanceTravelled: Double,
     val score: Int,
     @PrimaryKey(autoGenerate = true)
-    val id: Int
+    val id: Int,
+//    @ForeignKey(
+//        entity = VehicleTable::class,
+//        parentColumns = ["id"],
+//        childColumns = ["vehicleId"],
+//        onDelete = ForeignKey.CASCADE
+//    )
+    val vehicleId: Int,
+//    @ForeignKey()
+    val userId: Int,
 )

--- a/app/src/main/java/com/digitalarchitects/rmc_app/room/RmcRoomDatabase.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/room/RmcRoomDatabase.kt
@@ -3,15 +3,14 @@ package com.digitalarchitects.rmc_app.room
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverter
-import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
 @Database(
-    entities = [UserTable::class, /*VehicleTable::class, RentalTable::class*/],
-    version= 1
+    version = 1,
+    entities = [UserTable::class, VehicleTable::class, RentalTable::class]
 )
-abstract class RmcRoomDatabase:RoomDatabase() {
+abstract class RmcRoomDatabase : RoomDatabase() {
     abstract val userDao: UserDao
     abstract val vehicleDao: VehicleDao
     abstract val rentalDao: RentalDao
@@ -31,15 +30,3 @@ class LocalDateConverter {
         return value?.let { LocalDate.parse(it, formatter) }
     }
 }
-
-//
-//class BigDecimalConverter {
-//    @TypeConverter
-//    fun fromBigDecimal(value: BigDecimal?): String? {
-//        return value?.toString()
-//    }
-//    @TypeConverter
-//    fun toBigDecimal(value: String?): BigDecimal? {
-//        return value?.let { BigDecimal(it) }
-//    }
-//}

--- a/app/src/main/java/com/digitalarchitects/rmc_app/room/UserDao.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/room/UserDao.kt
@@ -4,7 +4,6 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Upsert
-import com.digitalarchitects.rmc_app.data.editmyaccount.EditMyAccountUIEvent
 import kotlinx.coroutines.flow.Flow
 
 @Dao

--- a/app/src/main/java/com/digitalarchitects/rmc_app/room/UserDao.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/room/UserDao.kt
@@ -25,6 +25,6 @@ interface UserDao {
     @Insert
     suspend fun insertUser(user:UserTable)
 
-//    @Delete
-//    suspend fun deleteUser()
+    @Delete
+    suspend fun deleteUser(user:UserTable)
 }

--- a/app/src/main/java/com/digitalarchitects/rmc_app/room/UserDao.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/room/UserDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Upsert
+import com.digitalarchitects.rmc_app.data.editmyaccount.EditMyAccountUIEvent
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -15,6 +16,9 @@ interface UserDao {
     // TODO GET CURRENT USER
 //    @Query("SELECT * FROM usertable LIMIT 1")
 //    fun getUser(): UserTable?
+
+    @Query("SELECT * FROM usertable WHERE id = 1")
+    fun getUserById(): UserTable
 
     @Query("SELECT firstName FROM usertable LIMIT 1")
     fun getFirstName(): String?

--- a/app/src/main/java/com/digitalarchitects/rmc_app/room/VehicleDao.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/room/VehicleDao.kt
@@ -1,29 +1,31 @@
 package com.digitalarchitects.rmc_app.room
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
 import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface VehicleDao {
 
-//    @Query("SELECT * FROM vehicletable ORDER BY id ASC")
-//    fun getVehiclesOrderedById(): Flow<List<VehicleTable>>
+    @Query("SELECT * FROM vehicletable ORDER BY id ASC")
+    fun getVehiclesOrderedById(): Flow<List<VehicleTable>>
 
-    // TODO GET CURRENT Vehicle
+//     TODO GET CURRENT Vehicle
 //    @Query("SELECT * FROM vehicletable LIMIT 1")
 //    fun getVehicle(): VehicleTable
-//
-//    @Query("SELECT model FROM vehicletable LIMIT 1")
-//    fun getVehicleModel(): String?
-//
-//    @Upsert
-//    suspend fun upsertVehicle(vehicle: VehicleTable)
-//
-//    @Insert
-//    suspend fun insertUser(vehicle: VehicleTable)
 
-//    @Delete
-//    suspend fun deleteVehicle()
+    @Query("SELECT model FROM vehicletable LIMIT 1")
+    fun getVehicleModel(): String?
+
+    @Upsert
+    suspend fun upsertVehicle(vehicle: VehicleTable)
+
+    @Insert
+    suspend fun insertUser(vehicle: VehicleTable)
+
+    @Delete
+    suspend fun deleteVehicle(vehicle: VehicleTable)
 }

--- a/app/src/main/java/com/digitalarchitects/rmc_app/room/VehicleTable.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/room/VehicleTable.kt
@@ -3,11 +3,10 @@ package com.digitalarchitects.rmc_app.room
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import androidx.room.TypeConverters
 import com.digitalarchitects.rmc_app.model.EngineType
 
 @Entity
-class VehicleTable (
+class VehicleTable(
     val userId: Int,
     val brand: String,
     val model: String,

--- a/app/src/main/java/com/digitalarchitects/rmc_app/screens/EditMyAccountScreen.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/screens/EditMyAccountScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -38,6 +39,7 @@ import com.digitalarchitects.rmc_app.components.RmcSpacer
 import com.digitalarchitects.rmc_app.components.RmcTextField
 import com.digitalarchitects.rmc_app.data.editmyaccount.EditMyAccountUIEvent
 import com.digitalarchitects.rmc_app.data.editmyaccount.EditMyAccountViewModel
+import com.digitalarchitects.rmc_app.data.myaccount.MyAccountUIEvent
 import com.digitalarchitects.rmc_app.data.myaccount.MyAccountViewModel
 import com.digitalarchitects.rmc_app.data.register.RegisterUIEvent
 
@@ -48,13 +50,17 @@ fun EditMyAccountScreen(
     onNavigateUp: () -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsState()
+    LaunchedEffect(Unit) {
+        viewModel.onEvent(EditMyAccountUIEvent.UpsertUser)
+        viewModel.onEvent(EditMyAccountUIEvent.ShowUser)
+    }
 
     Scaffold(
         topBar = {
             RmcAppBar(
                 title = R.string.screen_title_register,
                 navigationIcon = Icons.Rounded.ArrowBack,
-                navigateUp = { onNavigateUp() }
+                navigateUp = { onNavigateUp() },
             )
         }
     ) { innerPadding ->
@@ -153,18 +159,18 @@ fun EditMyAccountScreen(
 
                 RmcSpacer(8)
 
-                RmcTextField(
-                    label = stringResource(id = R.string.address),
-                    icon = Icons.Filled.Home,
-                    value = uiState.buildingNumber,
-                    keyboardOptions = KeyboardOptions.Default.copy(
-                        keyboardType = KeyboardType.Number,
-                        imeAction = ImeAction.Next
-                    ),
-                    onValueChange = {
-                        viewModel.onEvent(EditMyAccountUIEvent.SetStreet(it))
-                    }
-                )
+//                RmcTextField(
+//                    label = stringResource(id = R.string.address),
+//                    icon = Icons.Filled.Home,
+//                    value = uiState.buildingNumber,
+//                    keyboardOptions = KeyboardOptions.Default.copy(
+//                        keyboardType = KeyboardType.Number,
+//                        imeAction = ImeAction.Next
+//                    ),
+//                    onValueChange = {
+//                        viewModel.onEvent(EditMyAccountUIEvent.SetStreet(it))
+//                    }
+//                )
 
                 RmcSpacer(8)
 
@@ -218,14 +224,19 @@ fun EditMyAccountScreen(
                 RmcSpacer(32)
 
                 RmcFilledButton(
-                    value = stringResource(id = R.string.register),
+                    value = stringResource(id = R.string.cancel),
+                    onClick = {
+                    }
+                )
+                RmcFilledButton(
+                    value = stringResource(id = R.string.apply),
                     onClick = {
 //                        registerViewModel.onEvent(RegisterUIEvent.RegisterButtonClicked)
 //                        onRegisterButtonClicked()
                     }
                 )
 
-                DividerTextComponent()
+
 
             }
         }

--- a/app/src/main/java/com/digitalarchitects/rmc_app/screens/EditMyAccountScreen.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/screens/EditMyAccountScreen.kt
@@ -30,18 +30,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import com.digitalarchitects.rmc_app.R
-import com.digitalarchitects.rmc_app.components.CheckboxComponent
-import com.digitalarchitects.rmc_app.components.ClickableLoginTextComponent
-import com.digitalarchitects.rmc_app.components.DividerTextComponent
 import com.digitalarchitects.rmc_app.components.RmcAppBar
 import com.digitalarchitects.rmc_app.components.RmcFilledButton
 import com.digitalarchitects.rmc_app.components.RmcSpacer
 import com.digitalarchitects.rmc_app.components.RmcTextField
 import com.digitalarchitects.rmc_app.data.editmyaccount.EditMyAccountUIEvent
 import com.digitalarchitects.rmc_app.data.editmyaccount.EditMyAccountViewModel
-import com.digitalarchitects.rmc_app.data.myaccount.MyAccountUIEvent
-import com.digitalarchitects.rmc_app.data.myaccount.MyAccountViewModel
-import com.digitalarchitects.rmc_app.data.register.RegisterUIEvent
 
 
 @Composable
@@ -51,7 +45,7 @@ fun EditMyAccountScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     LaunchedEffect(Unit) {
-        viewModel.onEvent(EditMyAccountUIEvent.UpsertUser)
+        viewModel.onEvent(EditMyAccountUIEvent.InsertUser)
         viewModel.onEvent(EditMyAccountUIEvent.ShowUser)
     }
 
@@ -157,20 +151,21 @@ fun EditMyAccountScreen(
                     }
                 )
 
+
                 RmcSpacer(8)
 
-//                RmcTextField(
-//                    label = stringResource(id = R.string.address),
-//                    icon = Icons.Filled.Home,
-//                    value = uiState.buildingNumber,
-//                    keyboardOptions = KeyboardOptions.Default.copy(
-//                        keyboardType = KeyboardType.Number,
-//                        imeAction = ImeAction.Next
-//                    ),
-//                    onValueChange = {
-//                        viewModel.onEvent(EditMyAccountUIEvent.SetStreet(it))
-//                    }
-//                )
+                RmcTextField(
+                    label = stringResource(id = R.string.address),
+                    icon = Icons.Filled.Home,
+                    value = uiState.street,
+                    keyboardOptions = KeyboardOptions.Default.copy(
+                        keyboardType = KeyboardType.Number,
+                        imeAction = ImeAction.Next
+                    ),
+                    onValueChange = {
+                        viewModel.onEvent(EditMyAccountUIEvent.SetStreet(it))
+                    }
+                )
 
                 RmcSpacer(8)
 
@@ -226,16 +221,16 @@ fun EditMyAccountScreen(
                 RmcFilledButton(
                     value = stringResource(id = R.string.cancel),
                     onClick = {
+
                     }
                 )
                 RmcFilledButton(
                     value = stringResource(id = R.string.apply),
                     onClick = {
-//                        registerViewModel.onEvent(RegisterUIEvent.RegisterButtonClicked)
-//                        onRegisterButtonClicked()
+                        viewModel.onEvent(EditMyAccountUIEvent.ConfirmEditMyAccountButtonClicked)
+                        onNavigateUp()
                     }
                 )
-
 
 
             }

--- a/app/src/main/java/com/digitalarchitects/rmc_app/screens/EditMyAccountScreen.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/screens/EditMyAccountScreen.kt
@@ -52,7 +52,7 @@ fun EditMyAccountScreen(
     Scaffold(
         topBar = {
             RmcAppBar(
-                title = R.string.screen_title_register,
+                title = R.string.screen_title_edit_account,
                 navigationIcon = Icons.Rounded.ArrowBack,
                 navigateUp = { onNavigateUp() },
             )

--- a/app/src/main/java/com/digitalarchitects/rmc_app/screens/EditMyAccountScreen.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/screens/EditMyAccountScreen.kt
@@ -1,0 +1,233 @@
+package com.digitalarchitects.rmc_app.screens
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Call
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.LocationCity
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.Numbers
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.rounded.ArrowBack
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import com.digitalarchitects.rmc_app.R
+import com.digitalarchitects.rmc_app.components.CheckboxComponent
+import com.digitalarchitects.rmc_app.components.ClickableLoginTextComponent
+import com.digitalarchitects.rmc_app.components.DividerTextComponent
+import com.digitalarchitects.rmc_app.components.RmcAppBar
+import com.digitalarchitects.rmc_app.components.RmcFilledButton
+import com.digitalarchitects.rmc_app.components.RmcSpacer
+import com.digitalarchitects.rmc_app.components.RmcTextField
+import com.digitalarchitects.rmc_app.data.editmyaccount.EditMyAccountUIEvent
+import com.digitalarchitects.rmc_app.data.editmyaccount.EditMyAccountViewModel
+import com.digitalarchitects.rmc_app.data.myaccount.MyAccountViewModel
+import com.digitalarchitects.rmc_app.data.register.RegisterUIEvent
+
+
+@Composable
+fun EditMyAccountScreen(
+    viewModel: EditMyAccountViewModel,
+    onNavigateUp: () -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    Scaffold(
+        topBar = {
+            RmcAppBar(
+                title = R.string.screen_title_register,
+                navigationIcon = Icons.Rounded.ArrowBack,
+                navigateUp = { onNavigateUp() }
+            )
+        }
+    ) { innerPadding ->
+        Surface(
+            modifier = Modifier
+                .padding(innerPadding)
+                .fillMaxSize(),
+            color = MaterialTheme.colorScheme.surface
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(
+                        start = dimensionResource(R.dimen.padding_large),
+                        end = dimensionResource(R.dimen.padding_large)
+                    )
+                    .verticalScroll(rememberScrollState())
+            ) {
+                Row(
+                    modifier = Modifier,
+                    horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.padding_medium))
+                ) {
+                    RmcTextField(
+                        label = stringResource(id = R.string.first_name),
+                        icon = Icons.Filled.Person,
+                        value = uiState.firstName,
+                        keyboardOptions = KeyboardOptions.Default.copy(
+                            keyboardType = KeyboardType.Text,
+                            imeAction = ImeAction.Next
+                        ),
+                        onValueChange = {
+                            viewModel.onEvent(EditMyAccountUIEvent.SetFirstName(it))
+                        },
+                        modifier = Modifier.weight(1f)
+                    )
+                    RmcTextField(
+                        label = stringResource(id = R.string.last_name),
+                        icon = Icons.Filled.Person,
+                        value = uiState.lastName,
+                        keyboardOptions = KeyboardOptions.Default.copy(
+                            keyboardType = KeyboardType.Text,
+                            imeAction = ImeAction.Next
+                        ),
+                        onValueChange = {
+                            viewModel.onEvent(EditMyAccountUIEvent.SetLastName(it))
+                        },
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+
+                RmcSpacer(8)
+
+                RmcTextField(
+                    label = stringResource(id = R.string.email),
+                    icon = Icons.Filled.Email,
+                    value = uiState.email,
+                    keyboardOptions = KeyboardOptions.Default.copy(
+                        keyboardType = KeyboardType.Text,
+                        imeAction = ImeAction.Next
+                    ),
+                    onValueChange = {
+                        viewModel.onEvent(EditMyAccountUIEvent.SetEmail(it))
+                    }
+                )
+
+                RmcSpacer(8)
+
+                RmcTextField(
+                    label = stringResource(id = R.string.telephone),
+                    icon = Icons.Filled.Call,
+                    value = uiState.phone,
+                    keyboardOptions = KeyboardOptions.Default.copy(
+                        keyboardType = KeyboardType.Number,
+                        imeAction = ImeAction.Next
+                    ),
+                    onValueChange = {
+                        viewModel.onEvent(EditMyAccountUIEvent.SetPhone(it))
+                    }
+                )
+
+                RmcSpacer(8)
+
+                RmcTextField(
+                    label = stringResource(id = R.string.password),
+                    icon = Icons.Filled.Lock,
+                    value = uiState.password,
+                    keyboardOptions = KeyboardOptions.Default.copy(
+                        keyboardType = KeyboardType.Password,
+                        imeAction = ImeAction.Next
+                    ),
+                    isPassword = true,
+                    onValueChange = {
+                        viewModel.onEvent(EditMyAccountUIEvent.SetPassword(it))
+                    }
+                )
+
+                RmcSpacer(8)
+
+                RmcTextField(
+                    label = stringResource(id = R.string.address),
+                    icon = Icons.Filled.Home,
+                    value = uiState.buildingNumber,
+                    keyboardOptions = KeyboardOptions.Default.copy(
+                        keyboardType = KeyboardType.Number,
+                        imeAction = ImeAction.Next
+                    ),
+                    onValueChange = {
+                        viewModel.onEvent(EditMyAccountUIEvent.SetStreet(it))
+                    }
+                )
+
+                RmcSpacer(8)
+
+                Row(
+                    modifier = Modifier,
+                    horizontalArrangement = Arrangement.spacedBy(dimensionResource(R.dimen.padding_medium))
+                ) {
+                    RmcTextField(
+                        label = stringResource(id = R.string.postal_code),
+                        icon = Icons.Filled.Numbers,
+                        value = uiState.zipCode,
+                        keyboardOptions = KeyboardOptions.Default.copy(
+                            keyboardType = KeyboardType.Text,
+                            imeAction = ImeAction.Next
+                        ),
+                        onValueChange = {
+                            viewModel.onEvent(EditMyAccountUIEvent.SetZipCode(it))
+                        },
+                        modifier = Modifier.weight(1f)
+                    )
+                    RmcTextField(
+                        label = stringResource(id = R.string.building_number),
+                        icon = Icons.Filled.Numbers,
+                        value = uiState.buildingNumber,
+                        keyboardOptions = KeyboardOptions.Default.copy(
+                            keyboardType = KeyboardType.Number,
+                            imeAction = ImeAction.Next
+                        ),
+                        onValueChange = {
+                            viewModel.onEvent(EditMyAccountUIEvent.SetBuildingNumber(it))
+                        },
+                        modifier = Modifier.weight(1f)
+                    )
+                }
+
+                RmcSpacer(8)
+
+                RmcTextField(
+                    label = stringResource(id = R.string.city),
+                    icon = Icons.Filled.LocationCity,
+                    value = uiState.city,
+                    keyboardOptions = KeyboardOptions.Default.copy(
+                        keyboardType = KeyboardType.Text,
+                        imeAction = ImeAction.Done
+                    ),
+                    onValueChange = {
+                        viewModel.onEvent(EditMyAccountUIEvent.SetCity(it))
+                    }
+                )
+
+                RmcSpacer(32)
+
+                RmcFilledButton(
+                    value = stringResource(id = R.string.register),
+                    onClick = {
+//                        registerViewModel.onEvent(RegisterUIEvent.RegisterButtonClicked)
+//                        onRegisterButtonClicked()
+                    }
+                )
+
+                DividerTextComponent()
+
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/digitalarchitects/rmc_app/screens/MyAccountScreen.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/screens/MyAccountScreen.kt
@@ -33,7 +33,8 @@ import com.digitalarchitects.rmc_app.data.myaccount.MyAccountViewModel
 
 @Composable
 fun MyAccountScreen(
-    viewModel: MyAccountViewModel
+    viewModel: MyAccountViewModel,
+    onEditMyAccountButtonClicked: () -> Unit
 ) {
     val uiState by viewModel.uiState.collectAsState()
     LaunchedEffect(Unit) {
@@ -58,6 +59,7 @@ fun MyAccountScreen(
                 userIcon = uiState.imageResourceId,
                 size = dimensionResource(R.dimen.image_size_large),
                 onClick = {
+                    onEditMyAccountButtonClicked()
 //                    onEvent(MyAccountUIEvent.onEditMyAccountButtonClicked)
                 }
             )
@@ -70,6 +72,7 @@ fun MyAccountScreen(
                 value = stringResource(R.string.my_vehicles),
                 icon = Icons.Filled.DirectionsCar,
                 onClick = {
+
 //                    onEvent(MyAccountUIEvent.onMyVehiclesButtonClicked)
                 }
             )

--- a/app/src/main/java/com/digitalarchitects/rmc_app/screens/MyAccountScreen.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/screens/MyAccountScreen.kt
@@ -38,7 +38,7 @@ fun MyAccountScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     LaunchedEffect(Unit) {
-        viewModel.onEvent(MyAccountUIEvent.UpsertUser)
+        viewModel.onEvent(MyAccountUIEvent.InsertUser)
         viewModel.onEvent(MyAccountUIEvent.ShowUser)
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
     <string name="engine_type_fbev">FBEV</string>
     <string name="ok">Ok</string>
     <string name="apply">Apply</string>
+    <string name="cancel">Cancel</string>
     <string name="clear">Clear</string>
     <string name="hide_password">\"Hide password\"</string>
     <string name="show_password">\"Show password\"</string>


### PR DESCRIPTION
Created EditMyAccountScreen
The screen uses a viewmodel and room db implementation(see current Room PR for more info on Room)
Cleaned up my account and edit my account associated files, states, events, imports, coding style.
Instead of upsert a user with id 1 it inserts a user if there is no user with id 1. Making it easy to run without making dummy data until the api db is connected through retrofit.
Edit my account screen reads and updates a user record through the use of room, this happens when the apply button is used.

TODO 
validation 
use of Try Catch error messages
navigation
implementation user session(with datastore?)