### PR TITLE
Implemented DataStore to save user preferences

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -115,6 +115,9 @@ dependencies {
     // Coil
     implementation("io.coil-kt:coil-compose:2.5.0")
 
+    // DataStore
+    implementation("androidx.datastore:datastore-preferences:1.0.0")
+
     // JUnit test
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")

--- a/app/src/main/java/com/digitalarchitects/rmc_app/data/auth/AuthInterceptor.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/data/auth/AuthInterceptor.kt
@@ -1,8 +1,8 @@
 package com.digitalarchitects.rmc_app.data.auth
 
-import android.content.SharedPreferences
 import android.util.Log
 import com.digitalarchitects.rmc_app.data.remote.RmcApiService
+import com.digitalarchitects.rmc_app.domain.repo.UserPreferencesRepository
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Response
@@ -11,8 +11,9 @@ import javax.inject.Provider
 
 class AuthInterceptor @Inject constructor(
     private val rmcApiService: Provider<RmcApiService>,
-    private val prefs: SharedPreferences
+    private val userPreferencesRepository: UserPreferencesRepository
 ) : Interceptor {
+
 
     private suspend fun refreshToken(chain: Interceptor.Chain): Response {
         try {
@@ -21,13 +22,13 @@ class AuthInterceptor @Inject constructor(
             val newToken = rmcApiService.get().refreshToken().token
 
             // Save the new JWT token to shared preferences
-            prefs.edit().putString("jwtToken", newToken).apply()
+            userPreferencesRepository.saveJwt(newToken)
             Log.d("AuthInterceptor", "Refresh token successful")
         } catch (e: Exception) {
             Log.e("AuthInterceptor", "Error trying to refresh the token: $e")
         }
 
-        val token = prefs.getString("jwtToken", null)
+        val token = userPreferencesRepository.getJwtToken()
         val newRequest = chain.request()
             .newBuilder()
             .header("Authorization", "Bearer $token")
@@ -37,22 +38,25 @@ class AuthInterceptor @Inject constructor(
     }
 
     override fun intercept(chain: Interceptor.Chain): Response {
-        val token = prefs.getString("jwtToken", null)
-        return if (!token.isNullOrEmpty()) {
-            val newRequest = chain.request()
-                .newBuilder()
-                .header("Authorization", "Bearer $token")
-                .build()
-            val response = chain.proceed(newRequest)
-            if (response.code == 401) {
-                // If the response indicates unauthorized, try to refresh the token
-                runBlocking { refreshToken(chain) }
+        // Using runBlocking to call the suspend function within a non-suspend context
+        return runBlocking {
+            val token = userPreferencesRepository.getJwtToken()
+            if (!token.isNullOrEmpty()) {
+                val newRequest = chain.request()
+                    .newBuilder()
+                    .header("Authorization", "Bearer $token")
+                    .build()
+                val response = chain.proceed(newRequest)
+                if (response.code == 401) {
+                    // If the response indicates unauthorized, try to refresh the token
+                    refreshToken(chain)
+                } else {
+                    response
+                }
             } else {
-                response
+                // No token in shared preferences, proceed with the original request
+                chain.proceed(chain.request())
             }
-        } else {
-            // No token in shared preferences, proceed with the original request
-            chain.proceed(chain.request())
         }
     }
 }

--- a/app/src/main/java/com/digitalarchitects/rmc_app/data/di/DataStoreModule.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/data/di/DataStoreModule.kt
@@ -1,0 +1,39 @@
+package com.digitalarchitects.rmc_app.data.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.handlers.ReplaceFileCorruptionHandler
+import androidx.datastore.preferences.SharedPreferencesMigration
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Singleton
+
+private const val USER_PREFERENCES = "user_preferences"
+
+@InstallIn(SingletonComponent::class)
+@Module
+object DataStoreModule {
+
+    @Singleton
+    @Provides
+    fun providePreferencesDataStore(@ApplicationContext appContext: Context): DataStore<Preferences> {
+        return PreferenceDataStoreFactory.create(
+            corruptionHandler = ReplaceFileCorruptionHandler(
+                produceNewData = { emptyPreferences() }
+            ),
+            migrations = listOf(SharedPreferencesMigration(appContext,USER_PREFERENCES)),
+            scope = CoroutineScope(Dispatchers.IO + SupervisorJob()),
+            produceFile = { appContext.preferencesDataStoreFile(USER_PREFERENCES) }
+        )
+    }
+}

--- a/app/src/main/java/com/digitalarchitects/rmc_app/data/di/HiltModule.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/data/di/HiltModule.kt
@@ -1,21 +1,20 @@
 package com.digitalarchitects.rmc_app.data.di
 
-import android.app.Application
 import android.content.Context
-import android.content.SharedPreferences
 import androidx.room.Room
 import com.digitalarchitects.rmc_app.data.auth.AuthInterceptor
+import com.digitalarchitects.rmc_app.data.local.RmcRoomDatabase
+import com.digitalarchitects.rmc_app.data.local.RmcRoomDatabaseRepo
+import com.digitalarchitects.rmc_app.data.local.RmcRoomDatabaseRepoImpl
+import com.digitalarchitects.rmc_app.data.remote.RmcApiService
 import com.digitalarchitects.rmc_app.data.repo.RentalRepositoryImpl
 import com.digitalarchitects.rmc_app.data.repo.UserRepositoryImpl
 import com.digitalarchitects.rmc_app.data.repo.VehicleRepositoryImpl
 import com.digitalarchitects.rmc_app.domain.repo.RentalRepository
+import com.digitalarchitects.rmc_app.domain.repo.UserPreferencesRepository
 import com.digitalarchitects.rmc_app.domain.repo.UserRepository
 import com.digitalarchitects.rmc_app.domain.repo.VehicleRepository
 import com.digitalarchitects.rmc_app.domain.util.LocalDateAdapter
-import com.digitalarchitects.rmc_app.data.remote.RmcApiService
-import com.digitalarchitects.rmc_app.data.local.RmcRoomDatabase
-import com.digitalarchitects.rmc_app.data.local.RmcRoomDatabaseRepo
-import com.digitalarchitects.rmc_app.data.local.RmcRoomDatabaseRepoImpl
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.Module
@@ -53,9 +52,9 @@ object HiltModule {
     @Provides
     fun provideAuthInterceptor(
         rmcApiService: Provider<RmcApiService>,
-        prefs: SharedPreferences
+        userPreferencesRepository: UserPreferencesRepository
     ): AuthInterceptor {
-        return AuthInterceptor(rmcApiService, prefs)
+        return AuthInterceptor(rmcApiService, userPreferencesRepository)
     }
 
     @Singleton
@@ -105,10 +104,10 @@ object HiltModule {
     fun providesUserRepo(
         db: RmcRoomDatabaseRepo,
         api: RmcApiService,
-        prefs: SharedPreferences,
+        userPreferencesRepository: UserPreferencesRepository,
         @IoDispatcher dispatcher: CoroutineDispatcher
     ): UserRepository {
-        return UserRepositoryImpl(db, api, prefs, dispatcher)
+        return UserRepositoryImpl(db, api, userPreferencesRepository, dispatcher)
     }
 
     @Provides
@@ -129,12 +128,6 @@ object HiltModule {
         @IoDispatcher dispatcher: CoroutineDispatcher
     ): RentalRepository {
         return RentalRepositoryImpl(db, api, dispatcher)
-    }
-
-    @Provides
-    @Singleton
-    fun provideSharedPref(app: Application): SharedPreferences {
-        return app.getSharedPreferences("prefs", Context.MODE_PRIVATE)
     }
 
 }

--- a/app/src/main/java/com/digitalarchitects/rmc_app/domain/repo/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/domain/repo/UserPreferencesRepository.kt
@@ -1,0 +1,41 @@
+package com.digitalarchitects.rmc_app.domain.repo
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+
+class UserPreferencesRepository @Inject constructor(
+    private val dataStore: DataStore<Preferences>
+) {
+    private companion object {
+        val JWT_TOKEN = stringPreferencesKey("jwt_token")
+        val USER_ID = stringPreferencesKey("user_id")
+    }
+
+    suspend fun saveJwt(token: String) {
+        dataStore.edit { preferences ->
+            preferences[JWT_TOKEN] = token
+        }
+    }
+
+    suspend fun saveUserId(userId: String) {
+        dataStore.edit { preferences ->
+            preferences[USER_ID] = userId
+        }
+    }
+
+    // Read JWT token from DataStore
+    suspend fun getJwtToken(): String? {
+        val preferences = dataStore.data.first()
+        return preferences[JWT_TOKEN]
+    }
+
+    // Read User ID from DataStore
+    suspend fun getUserId(): String? {
+        val preferences = dataStore.data.first()
+        return preferences[USER_ID]
+    }
+}

--- a/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/myaccount/MyAccountViewModel.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/myaccount/MyAccountViewModel.kt
@@ -1,35 +1,52 @@
 package com.digitalarchitects.rmc_app.presentation.screens.myaccount
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.digitalarchitects.rmc_app.data.di.IoDispatcher
 import com.digitalarchitects.rmc_app.data.local.LocalUser
+import com.digitalarchitects.rmc_app.domain.model.User
 import com.digitalarchitects.rmc_app.domain.model.UserType
 import com.digitalarchitects.rmc_app.domain.repo.UserRepository
 import com.digitalarchitects.rmc_app.presentation.RmcScreen
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
 class MyAccountViewModel @Inject constructor(
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    @IoDispatcher private val dispatcher: CoroutineDispatcher
 ) : ViewModel() {
     private val _navigateToScreen = MutableStateFlow<RmcScreen?>(null)
     val navigateToScreen = _navigateToScreen.asStateFlow()
     private val _state = MutableStateFlow(MyAccountUIState())
     private val _uiState = _state
     val uiState: StateFlow<MyAccountUIState> = _uiState.asStateFlow()
+
+
+    fun getUsers() {
+        viewModelScope.launch(dispatcher) {
+
+            val result: Result<List<User>> = runCatching {
+                userRepository.getAllUsers()
+            }
+        }
+    }
+
     fun onEvent(event: MyAccountUIEvent) {
         when (event) {
             is MyAccountUIEvent.ShowUser -> {
                 try {
                     runBlocking {
                         val firstName = withContext(Dispatchers.IO) {
-                            userRepository.getFirstName("1")
+                            userRepository.getFirstName("659579bb24eca74f47b8d194")
                         }
                         _state.value = _state.value.copy(firstName = "$firstName")
                     }


### PR DESCRIPTION
### Description:
This pull request introduces the implementation of Android's DataStore to manage user preferences in the RMC (Rent My Car) application. The changes include the creation of a UserPreferencesRepository interface and a DataStoreModule using Dagger Hilt for Dependency Injection.

### Changes Made
**DataStoreModule:**

- Added a new Hilt module (DataStoreModule) annotated with @InstallIn(SingletonComponent::class) to provide a DataStore for storing user preferences.
- Utilized PreferenceDataStoreFactory.create to set up DataStore with proper configurations, including a corruption handler and migrations.
- Scoped the DataStore operations within a CoroutineScope for asynchronous handling.
- Defined a method providePreferencesDataStore to offer the DataStore instance for injection.

**UserPreferencesRepository:**

- Created a UserPreferencesRepository class that uses DataStore to manage user preferences.
- Defined functions to save JWT tokens (saveJwt) and user IDs (saveUserId) to DataStore.
- Implemented functions to retrieve JWT tokens (getJwtToken) and user IDs (getUserId) from DataStore asynchronously using flows.

This implementation seamlessly integrates with the existing AuthInterceptor class and UserRepository, allowing the application to save and retrieve tokens during user authentication and token refresh processes.

Please use the UserPreferencesRepository and implement functions for your logic to save user preferences.

