### PR TITLE
Implement data store for search

### DIFF
--- a/app/src/main/java/com/digitalarchitects/rmc_app/domain/repo/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/domain/repo/UserPreferencesRepository.kt
@@ -2,6 +2,8 @@ package com.digitalarchitects.rmc_app.domain.repo
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.doublePreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.first
@@ -13,6 +15,14 @@ class UserPreferencesRepository @Inject constructor(
     private companion object {
         val JWT_TOKEN = stringPreferencesKey("jwt_token")
         val USER_ID = stringPreferencesKey("user_id")
+        val DATE = stringPreferencesKey("Date!")
+        val LOCATION = stringPreferencesKey("Location!")
+        val PRICE = doublePreferencesKey(55.0.toString())
+        val DISTANCE = doublePreferencesKey(55.0.toString())
+        val ENGINETYPEICE = booleanPreferencesKey(true.toString())
+        val ENGINETYPEBEV = booleanPreferencesKey(true.toString())
+        val ENGINETYPEFCEV = booleanPreferencesKey(true.toString())
+
     }
 
     suspend fun saveJwt(token: String) {
@@ -38,4 +48,51 @@ class UserPreferencesRepository @Inject constructor(
         val preferences = dataStore.data.first()
         return preferences[USER_ID]
     }
+
+    // save filter preference of user in datastore
+    suspend fun saveFilterPreference(
+        date: String,
+        location: String,
+        price: Double,
+        distance: Double,
+        engineTypeICE: Boolean,
+        engineTypeBEV: Boolean,
+        engineTypeFCEV: Boolean
+    ) {
+        dataStore.edit { preferences ->
+            preferences[DATE] = date
+            preferences[LOCATION] = location
+            preferences[PRICE] = price
+            preferences[DISTANCE] = distance
+            preferences[ENGINETYPEICE] = engineTypeICE
+            preferences[ENGINETYPEBEV] = engineTypeBEV
+            preferences[ENGINETYPEFCEV] = engineTypeFCEV
+        }
+    }
+
+    // get filter preference from user from datastore
+    suspend fun getFilterStates(): FilterStates {
+        val preferences = dataStore.data.first()
+        return FilterStates(
+            date = preferences[DATE] ?: "",
+            location = preferences[LOCATION] ?: "",
+            price = preferences[PRICE] ?: 0.0,
+            distance = preferences[DISTANCE] ?: 0.0,
+            engineTypeICE = preferences[ENGINETYPEICE] ?: true,
+            engineTypeBEV = preferences[ENGINETYPEBEV] ?: true,
+            engineTypeFCEV = preferences[ENGINETYPEFCEV] ?: true
+        )
+    }
+
+    // data class to hold and handle filter preference data
+    data class FilterStates(
+        val date: String,
+        val location: String,
+        val price: Double,
+        val distance: Double,
+        val engineTypeICE: Boolean,
+        val engineTypeBEV: Boolean,
+        val engineTypeFCEV: Boolean
+    )
+
 }

--- a/app/src/main/java/com/digitalarchitects/rmc_app/domain/repo/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/domain/repo/UserPreferencesRepository.kt
@@ -2,8 +2,6 @@ package com.digitalarchitects.rmc_app.domain.repo
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.booleanPreferencesKey
-import androidx.datastore.preferences.core.doublePreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.first
@@ -15,14 +13,13 @@ class UserPreferencesRepository @Inject constructor(
     private companion object {
         val JWT_TOKEN = stringPreferencesKey("jwt_token")
         val USER_ID = stringPreferencesKey("user_id")
-        val DATE = stringPreferencesKey("Date!")
-        val LOCATION = stringPreferencesKey("Location!")
-        val PRICE = doublePreferencesKey(55.0.toString())
-        val DISTANCE = doublePreferencesKey(55.0.toString())
-        val ENGINETYPEICE = booleanPreferencesKey(true.toString())
-        val ENGINETYPEBEV = booleanPreferencesKey(true.toString())
-        val ENGINETYPEFCEV = booleanPreferencesKey(true.toString())
-
+        val DATE = stringPreferencesKey("")
+        val LOCATION = stringPreferencesKey("")
+        val PRICE = stringPreferencesKey("")
+        val DISTANCE = stringPreferencesKey("")
+        val ENGINETYPEICE = stringPreferencesKey("")
+        val ENGINETYPEBEV = stringPreferencesKey("")
+        val ENGINETYPEFCEV = stringPreferencesKey("")
     }
 
     suspend fun saveJwt(token: String) {
@@ -62,25 +59,25 @@ class UserPreferencesRepository @Inject constructor(
         dataStore.edit { preferences ->
             preferences[DATE] = date
             preferences[LOCATION] = location
-            preferences[PRICE] = price
-            preferences[DISTANCE] = distance
-            preferences[ENGINETYPEICE] = engineTypeICE
-            preferences[ENGINETYPEBEV] = engineTypeBEV
-            preferences[ENGINETYPEFCEV] = engineTypeFCEV
+            preferences[PRICE] = price.toString()
+            preferences[DISTANCE] = distance.toString()
+            preferences[ENGINETYPEICE] = engineTypeICE.toString()
+            preferences[ENGINETYPEBEV] = engineTypeBEV.toString()
+            preferences[ENGINETYPEFCEV] = engineTypeFCEV.toString()
         }
     }
 
     // get filter preference from user from datastore
-    suspend fun getFilterStates(): FilterStates {
+    suspend fun getFilterPreference(): FilterStates {
         val preferences = dataStore.data.first()
         return FilterStates(
-            date = preferences[DATE] ?: "",
-            location = preferences[LOCATION] ?: "",
-            price = preferences[PRICE] ?: 0.0,
-            distance = preferences[DISTANCE] ?: 0.0,
-            engineTypeICE = preferences[ENGINETYPEICE] ?: true,
-            engineTypeBEV = preferences[ENGINETYPEBEV] ?: true,
-            engineTypeFCEV = preferences[ENGINETYPEFCEV] ?: true
+            date = preferences[DATE] ?: "Date",
+            location = preferences[LOCATION] ?: "Location",
+            price = preferences[PRICE]?.toDouble() ?: 55.0,
+            distance = preferences[DISTANCE]?.toDouble() ?: 4.1,
+            engineTypeICE = preferences[ENGINETYPEICE]?.toBoolean() ?: true,
+            engineTypeBEV = preferences[ENGINETYPEBEV]?.toBoolean() ?: true,
+            engineTypeFCEV = preferences[ENGINETYPEFCEV]?.toBoolean() ?: true
         )
     }
 

--- a/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchScreen.kt
@@ -54,7 +54,7 @@ fun SearchScreen(
     val uiState by viewModel.uiState.collectAsState()
 
     LaunchedEffect(Unit) {
-// TODO Default state values
+        viewModel.onEvent(SearchUIEvent.FetchFilterPreference)
     }
 
     Scaffold(

--- a/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchScreen.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchScreen.kt
@@ -85,13 +85,13 @@ fun SearchScreen(
                     RmcTextField(
                         label = stringResource(id = R.string.date),
                         icon = Icons.Filled.CalendarMonth,
-                        value = "searchUiState.date ?: ",
+                        value = uiState.date,
                         keyboardOptions = KeyboardOptions.Default.copy(
                             keyboardType = KeyboardType.Text,
                             imeAction = ImeAction.Next
                         ),
-                        onValueChange = {
-                            // TODO searchViewModel.onEvent(SearchUIEvent.DateChanged(it))
+                        onValueChange = { date ->
+                            viewModel.onEvent(SearchUIEvent.DateChanged(date))
                         },
                         modifier = Modifier.fillMaxWidth()
                     )
@@ -101,13 +101,13 @@ fun SearchScreen(
                     RmcTextField(
                         label = stringResource(id = R.string.location),
                         icon = Icons.Filled.LocationOn,
-                        value = "searchUiState.location ?: ",
+                        value = uiState.location,
                         keyboardOptions = KeyboardOptions.Default.copy(
                             keyboardType = KeyboardType.Text,
-                            imeAction = ImeAction.None
+                            imeAction = ImeAction.Next
                         ),
-                        onValueChange = {
-                            // TODO searchViewModel.onEvent(SearchUIEvent.LocationChanged(it))
+                        onValueChange = { location ->
+                            viewModel.onEvent(SearchUIEvent.LocationChanged(location))
                         },
                         modifier = Modifier.fillMaxWidth()
                     )
@@ -117,10 +117,10 @@ fun SearchScreen(
                     RmcSlider(
                         label = stringResource(id = R.string.price),
                         icon = Icons.Filled.PriceChange,
-                        sliderPosition = /*searchUiState.price?.toFloat() ?:*/ 0.0F,
+                        sliderPosition = uiState.price.toFloat(),
                         maxValue = 250.0F,
-                        onValueChange = {
-                            //TODO     searchViewModel.onEvent(SearchUIEvent.PriceChanged(it))
+                        onValueChange = { price ->
+                            viewModel.onEvent(SearchUIEvent.PriceChanged(price))
                         }
                     )
 
@@ -129,10 +129,10 @@ fun SearchScreen(
                     RmcSlider(
                         label = stringResource(id = R.string.distance),
                         icon = Icons.Filled.LocationOn,
-                        sliderPosition = /*searchUiState.distance?.toFloat() ?:*/ 0.0F,
+                        sliderPosition = uiState.distance.toFloat(),
                         maxValue = 250.0F,
-                        onValueChange = {
-                            //TODO  searchViewModel.onEvent(SearchUIEvent.DistanceChanged(it))
+                        onValueChange = { distance ->
+                            viewModel.onEvent(SearchUIEvent.DistanceChanged(distance))
                         }
                     )
 
@@ -148,8 +148,8 @@ fun SearchScreen(
                             RmcFilterChip(
                                 label = stringResource(id = R.string.engine_type_ice),
                                 selected = uiState.engineTypeIce,
-                                onClick = {
-                                    //TODO
+                                onClick = { ice ->
+                                    viewModel.onEvent(SearchUIEvent.EngineTypeIceChanged(ice))
                                 }
                             )
                         }
@@ -157,8 +157,8 @@ fun SearchScreen(
                             RmcFilterChip(
                                 label = stringResource(id = R.string.engine_type_bev),
                                 selected = uiState.engineTypeBev,
-                                onClick = {
-                                    //   TODO
+                                onClick = { bev ->
+                                    viewModel.onEvent(SearchUIEvent.EngineTypeBevChanged(bev))
                                 }
                             )
                         }
@@ -166,8 +166,8 @@ fun SearchScreen(
                             RmcFilterChip(
                                 label = stringResource(id = R.string.engine_type_fcev),
                                 selected = uiState.engineTypeFcev,
-                                onClick = {
-                                    // TODO
+                                onClick = { fcev ->
+                                    viewModel.onEvent(SearchUIEvent.EngineTypeFcevChanged(fcev))
                                 }
                             )
                         }
@@ -183,7 +183,7 @@ fun SearchScreen(
                         RmcOutlinedButton(
                             value = stringResource(id = R.string.clear),
                             onClick = {
-                                // TODO: clearFilters
+                                viewModel.onEvent(SearchUIEvent.ClearFiltersButtonClicked)
                             }
                         )
                     }
@@ -191,7 +191,7 @@ fun SearchScreen(
                         RmcFilledButton(
                             value = stringResource(id = R.string.apply),
                             onClick = {
-                                // TODO: applyFilters
+                                viewModel.onEvent(SearchUIEvent.ApplyFiltersButtonClicked)
                                 navigateToScreen(RmcScreen.RentACar.name)
                             }
                         )

--- a/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchUIEvent.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchUIEvent.kt
@@ -2,7 +2,7 @@ package com.digitalarchitects.rmc_app.presentation.screens.search
 
 
 sealed class SearchUIEvent {
-    object FetchFilterPreference: SearchUIEvent()
+    object FetchFilterPreference : SearchUIEvent()
     data class DateChanged(val date: String) : SearchUIEvent()
     data class LocationChanged(val location: String) : SearchUIEvent()
     data class PriceChanged(val price: Float) : SearchUIEvent()

--- a/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchUIEvent.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchUIEvent.kt
@@ -6,8 +6,8 @@ sealed class SearchUIEvent {
     data class PriceChanged(val price: Float) : SearchUIEvent()
     data class DistanceChanged(val distance: Float) : SearchUIEvent()
     data class EngineTypeIceChanged(val selected: Boolean) : SearchUIEvent()
-    data class EngineTypeCevChanged(val selected: Boolean) : SearchUIEvent()
-    data class EngineTypeFbevChanged(val selected: Boolean) : SearchUIEvent()
+    data class EngineTypeBevChanged(val selected: Boolean) : SearchUIEvent()
+    data class EngineTypeFcevChanged(val selected: Boolean) : SearchUIEvent()
     object ApplyFiltersButtonClicked : SearchUIEvent()
     object ClearFiltersButtonClicked : SearchUIEvent()
 }

--- a/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchUIEvent.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchUIEvent.kt
@@ -1,6 +1,8 @@
 package com.digitalarchitects.rmc_app.presentation.screens.search
 
+
 sealed class SearchUIEvent {
+    object FetchFilterPreference: SearchUIEvent()
     data class DateChanged(val date: String) : SearchUIEvent()
     data class LocationChanged(val location: String) : SearchUIEvent()
     data class PriceChanged(val price: Float) : SearchUIEvent()

--- a/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchUIState.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchUIState.kt
@@ -3,10 +3,10 @@ package com.digitalarchitects.rmc_app.presentation.screens.search
 // TODO: Hoist all search settings to Rent A Car screen to show results
 
 data class SearchUIState(
-    val date: String? = "Date!", // TODO: Make LocalDate, maybe with LocalDate.now()
-    val location: String? = "Location!",
-    val price: Double? = 55.0,
-    val distance: Int? = 53,
+    val date: String = "", // TODO: Make LocalDate, maybe with LocalDate.now()
+    val location: String = "",
+    val price: Double = 0.0,
+    val distance: Int = 0,
     val engineTypeIce: Boolean = true,
     val engineTypeBev: Boolean = true,
     val engineTypeFcev: Boolean = true

--- a/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchUIState.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchUIState.kt
@@ -6,7 +6,7 @@ data class SearchUIState(
     val date: String = "", // TODO: Make LocalDate, maybe with LocalDate.now()
     val location: String = "",
     val price: Double = 0.0,
-    val distance: Int = 0,
+    val distance: Double = 0.0,
     val engineTypeIce: Boolean = true,
     val engineTypeBev: Boolean = true,
     val engineTypeFcev: Boolean = true

--- a/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchViewModel.kt
@@ -1,11 +1,14 @@
 package com.digitalarchitects.rmc_app.presentation.screens.search
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.digitalarchitects.rmc_app.domain.repo.UserPreferencesRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -17,17 +20,17 @@ class SearchViewModel @Inject constructor(
     val uiState: StateFlow<SearchUIState> = _uiState.asStateFlow()
 
     // TODO: Initialize search options based on current settings, passed in by the NavHost
-    init {
-        _uiState.value = _uiState.value.copy(
-            date = LocalDate.now().plusDays(1).toString(),
-            location = "Breda",
-            price = 0.0,
-            distance = 0,
-            engineTypeIce = true,
-            engineTypeBev = false,
-            engineTypeFcev = true
-        )
-    }
+//    init {
+//        _uiState.value = _uiState.value.copy(
+//            date = LocalDate.now().plusDays(1).toString(),
+//            location = "Breda",
+//            price = 0.0,
+//            distance = 0,
+//            engineTypeIce = true,
+//            engineTypeBev = false,
+//            engineTypeFcev = true
+//        )
+//    }
 
     fun onEvent(event: SearchUIEvent) {
         when (event) {
@@ -51,7 +54,7 @@ class SearchViewModel @Inject constructor(
 
             is SearchUIEvent.DistanceChanged -> {
                 _uiState.value = _uiState.value.copy(
-                    distance = event.distance.toInt()
+                    distance = event.distance.toDouble()
                 )
             }
 
@@ -82,13 +85,44 @@ class SearchViewModel @Inject constructor(
             }
 
             is SearchUIEvent.FetchFilterPreference -> {
+                viewModelScope.launch {
+                    try{
+                        val filterPreferences = userPreferencesRepository.getFilterPreference()
 
+                        _uiState.value = _uiState.value.copy(
+                            date = filterPreferences.date,
+                            location = filterPreferences.location,
+                            price = filterPreferences.price,
+                            distance = filterPreferences.distance,
+                            engineTypeIce = filterPreferences.engineTypeICE,
+                            engineTypeBev = filterPreferences.engineTypeBEV,
+                            engineTypeFcev = filterPreferences.engineTypeFCEV
+                        )
+                    } catch (e: Exception){
+                        Log.d("SearchViewModel", "Error fetching filter preference: $e")
+                    }
+                }
             }
         }
     }
 
     private fun applyFilters() {
-        TODO("Implement callback to NavHost with filters to Rent A Car view for search")
+        val state = _uiState.value
+        try {
+            viewModelScope.launch {
+                userPreferencesRepository.saveFilterPreference(
+                    date = state.date,
+                    location = state.location,
+                    price = state.price,
+                    distance = state.distance,
+                    engineTypeICE = state.engineTypeIce,
+                    engineTypeBEV = state.engineTypeBev,
+                    engineTypeFCEV =state.engineTypeFcev
+                )
+            }
+        } catch (e:Exception){
+            Log.d("SearchViewModel", "Error applying filter preference: $e")
+        }
     }
 
     private fun clearFilters() {
@@ -96,7 +130,7 @@ class SearchViewModel @Inject constructor(
             date = "",
             location = "",
             price = 0.0,
-            distance = 0,
+            distance = 0.0,
             engineTypeIce = true,
             engineTypeBev = true,
             engineTypeFcev = true

--- a/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchViewModel.kt
@@ -5,6 +5,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import java.time.LocalDate
 import javax.inject.Inject
 
 @HiltViewModel
@@ -16,8 +17,8 @@ class SearchViewModel @Inject constructor(
     // TODO: Initialize search options based on current settings, passed in by the NavHost
     init {
         _uiState.value = _uiState.value.copy(
-            date = "Date from NavHost",
-            location = "Location from NavHost",
+            date = LocalDate.now().plusDays(1).toString(),
+            location = "Breda",
             price = 0.0,
             distance = 0,
             engineTypeIce = true,
@@ -58,13 +59,13 @@ class SearchViewModel @Inject constructor(
                 )
             }
 
-            is SearchUIEvent.EngineTypeCevChanged -> {
+            is SearchUIEvent.EngineTypeBevChanged -> {
                 _uiState.value = _uiState.value.copy(
                     engineTypeBev = !event.selected
                 )
             }
 
-            is SearchUIEvent.EngineTypeFbevChanged -> {
+            is SearchUIEvent.EngineTypeFcevChanged -> {
                 _uiState.value = _uiState.value.copy(
                     engineTypeFcev = !event.selected
                 )

--- a/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchViewModel.kt
@@ -19,19 +19,6 @@ class SearchViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(SearchUIState())
     val uiState: StateFlow<SearchUIState> = _uiState.asStateFlow()
 
-    // TODO: Initialize search options based on current settings, passed in by the NavHost
-//    init {
-//        _uiState.value = _uiState.value.copy(
-//            date = LocalDate.now().plusDays(1).toString(),
-//            location = "Breda",
-//            price = 0.0,
-//            distance = 0,
-//            engineTypeIce = true,
-//            engineTypeBev = false,
-//            engineTypeFcev = true
-//        )
-//    }
-
     fun onEvent(event: SearchUIEvent) {
         when (event) {
             is SearchUIEvent.DateChanged -> {

--- a/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchViewModel.kt
@@ -1,6 +1,7 @@
 package com.digitalarchitects.rmc_app.presentation.screens.search
 
 import androidx.lifecycle.ViewModel
+import com.digitalarchitects.rmc_app.domain.repo.UserPreferencesRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -10,6 +11,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SearchViewModel @Inject constructor(
+    private val userPreferencesRepository: UserPreferencesRepository
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(SearchUIState())
     val uiState: StateFlow<SearchUIState> = _uiState.asStateFlow()

--- a/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/presentation/screens/search/SearchViewModel.kt
@@ -80,6 +80,10 @@ class SearchViewModel @Inject constructor(
             is SearchUIEvent.ApplyFiltersButtonClicked -> {
                 applyFilters()
             }
+
+            is SearchUIEvent.FetchFilterPreference -> {
+
+            }
         }
     }
 


### PR DESCRIPTION
Preperations by Paul:
- adjustments made to uistate for working with data store
- adjustments made to uievents for implementation
- screens made stateless 
- composables using states and events for onclicks, and interactions
- implemented userpreferencerepository in viewmodel

Finishing by Brian:
- added date, location, price, distance and enginetype preferences.
- added save filter preference function
- added get filter preference function
- added data class for holding and handling preferences

- added launched effect fetchfilterpreference on screen
- added object fetchfilterpreference() on UIevent
- added implementation onEvent fetchfilterPreference in viewmodel

- Moved toString to function instead of directly in the preference in the repo
- Implemented try catch on datastore access with log
- changed uistate distance from int to double

