### PR TITLE
Deploy firebase

### DIFF
--- a/.github/workflows/manual_deploy_to_firebase.yml
+++ b/.github/workflows/manual_deploy_to_firebase.yml
@@ -1,0 +1,40 @@
+name: Deploy to Firebase
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_notes:
+        type: string
+        required: true
+        default: 'Manual Debug Build'
+        description: 'Release Notes'
+
+jobs:
+  build:
+    name: Building and distributing app
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Execute Gradle command - assembleDebug
+        run: ./gradlew assembleDebug
+
+      - name: Upload Artifact to Firebase App Distribution
+        uses: Digital-Architects-Avans/rmc-app@v1
+        with:
+          appId: ${{ secrets.FIREBASE_APP_ID }}
+          serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
+          groups: testers
+          file: app/build/outputs/apk/debug/app-debug.apk
+          releaseNotes: ${{ inputs.release_notes }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     id("com.google.devtools.ksp")
     id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
     id("com.google.dagger.hilt.android")
+    id("com.google.gms.google-services")
 }
 
 val bundleId = "com.digitalarchitects.rmc_app"
@@ -148,6 +149,9 @@ dependencies {
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.2")
     androidTestImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.2")
 
+    // Firebase
+    implementation(platform("com.google.firebase:firebase-bom:32.7.0"))
+    implementation("com.google.firebase:firebase-analytics")
 
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/app/src/main/java/com/digitalarchitects/rmc_app/data/di/HiltModule.kt
+++ b/app/src/main/java/com/digitalarchitects/rmc_app/data/di/HiltModule.kt
@@ -83,7 +83,7 @@ object HiltModule {
         // Change to production URL when deploying
         // Also change the URL in FileRepositoryImpl.kt for getting profile images
         return Retrofit.Builder()
-            .baseUrl("http://10.0.2.2:8080/")
+            .baseUrl("https://rmc-ktor-api-2.ew.r.appspot.com/")
             .addConverterFactory(MoshiConverterFactory.create(moshi))
             .client(client)
             .build()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("org.jetbrains.kotlin.android") version "1.8.10" apply false
     id("com.google.devtools.ksp") version "1.9.10-1.0.13" apply false
     id("com.google.dagger.hilt.android") version "2.48" apply false
+    id("com.google.gms.google-services") version "4.4.0" apply false
 }
 
 buildscript {


### PR DESCRIPTION
- Created a Github Action Workflow for manual deploy to Firebase.
- Added required dependencies.


**ATTENTION:**
- In this build the retrofit builder URL for the API is set to the Google Cloud App Engine URL, Revert back to `http://10.0.2.2:8080/` for local testing